### PR TITLE
Add a logging system

### DIFF
--- a/app/Icepeak.hs
+++ b/app/Icepeak.hs
@@ -23,7 +23,7 @@ installHandlers core serverThread =
     handle = do
       Core.postQuit core
       Async.cancel serverThread
-      putStrLn "\nTermination sequence initiated ..."
+      Core.log "\nTermination sequence initiated ..." core
     handler = Signals.CatchOnce handle
     blockSignals = Nothing
     installHandler signal = Signals.installHandler signal handler blockSignals
@@ -46,7 +46,6 @@ main = do
   void $ Async.wait upds
   void $ Async.wait serv
   void $ Async.wait logger
-  putStrLn "okdoei"
 
 
 processLogRecords :: Core -> IO ()

--- a/icepeak.cabal
+++ b/icepeak.cabal
@@ -54,6 +54,7 @@ executable icepeak
   build-depends: async   >= 2.1  && < 2.2
                , base    >= 4.8  && < 5.0
                , scotty  >= 0.11 && < 0.12
+               , stm     >= 2.4  && < 2.5
                , unix    >= 2.7  && < 2.8
                , icepeak
 

--- a/icepeak.cabal
+++ b/icepeak.cabal
@@ -12,6 +12,7 @@ library
   exposed-modules: Core
                  , Guardian
                  , HttpServer
+                 , Logger
                  , Server
                  , Store
                  , Subscription

--- a/src/Core.hs
+++ b/src/Core.hs
@@ -22,7 +22,6 @@ import Control.Concurrent.STM.TBQueue (TBQueue, newTBQueueIO, readTBQueue, write
 import Control.Concurrent.STM.TVar (TVar, newTVarIO, writeTVar, readTVar)
 import Control.Monad (unless)
 import Data.Aeson (Value (..))
-import Data.Text (Text)
 import Data.UUID (UUID)
 import Prelude hiding (log)
 import Store (Path)
@@ -48,7 +47,7 @@ data Updated = Updated Path Value deriving (Eq, Show)
 
 data EnqueueResult = Enqueued | Dropped
 
-type LogRecord = Text
+type LogRecord = String
 
 data Core = Core
   { coreCurrentValue :: TVar Value

--- a/src/Core.hs
+++ b/src/Core.hs
@@ -9,7 +9,6 @@ module Core
   getCurrentValue,
   handleOp,
   lookup,
-  log,
   newCore,
   postQuit,
   processOps
@@ -28,6 +27,9 @@ import Store (Path)
 import Subscription (SubscriptionTree, empty)
 
 import qualified Network.WebSockets as WS
+
+import Logger (LogRecord)
+
 import qualified Store
 
 -- A modification operation.
@@ -47,8 +49,6 @@ data Updated = Updated Path Value deriving (Eq, Show)
 
 data EnqueueResult = Enqueued | Dropped
 
-type LogRecord = String
-
 data Core = Core
   { coreCurrentValue :: TVar Value
   , coreQueue :: TBQueue (Maybe Op)
@@ -58,11 +58,6 @@ data Core = Core
   }
 
 type ServerState = SubscriptionTree UUID WS.Connection
-
-log :: LogRecord -> Core -> IO ()
-log record core = atomically $ do
-  isFull <- isFullTBQueue (coreLogRecords core)
-  unless isFull $ writeTBQueue (coreLogRecords core) (Just record)
 
 newServerState :: ServerState
 newServerState = empty

--- a/src/Logger.hs
+++ b/src/Logger.hs
@@ -27,5 +27,5 @@ processLogRecords logRecords = go
         Just logRecord -> do
           putStrLn $ show logRecord
           go
-        -- stop the loop
+        -- Stop the loop when we receive a Nothing.
         Nothing -> pure ()

--- a/src/Logger.hs
+++ b/src/Logger.hs
@@ -1,0 +1,31 @@
+module Logger
+(
+  LogRecord,
+  log,
+  processLogRecords
+)
+where
+
+import Control.Monad (unless)
+import Control.Concurrent.STM (atomically)
+import Control.Concurrent.STM.TBQueue (TBQueue, readTBQueue, writeTBQueue, isFullTBQueue)
+import Prelude hiding (log)
+
+type LogRecord = String
+
+log :: LogRecord -> TBQueue (Maybe LogRecord) -> IO ()
+log record logRecords = atomically $ do
+  isFull <- isFullTBQueue logRecords
+  unless isFull $ writeTBQueue logRecords (Just record)
+
+processLogRecords :: TBQueue (Maybe LogRecord) -> IO ()
+processLogRecords logRecords = go
+  where
+    go = do
+      maybeLogRecord <- atomically $ readTBQueue logRecords
+      case maybeLogRecord of
+        Just logRecord -> do
+          putStrLn $ show logRecord
+          go
+        -- stop the loop
+        Nothing -> pure ()

--- a/src/Logger.hs
+++ b/src/Logger.hs
@@ -9,9 +9,12 @@ where
 import Control.Monad (unless)
 import Control.Concurrent.STM (atomically)
 import Control.Concurrent.STM.TBQueue (TBQueue, readTBQueue, writeTBQueue, isFullTBQueue)
+import Data.Text (Text)
 import Prelude hiding (log)
 
-type LogRecord = String
+import qualified Data.Text.IO as T
+
+type LogRecord = Text
 
 log :: LogRecord -> TBQueue (Maybe LogRecord) -> IO ()
 log record logRecords = atomically $ do
@@ -25,7 +28,7 @@ processLogRecords logRecords = go
       maybeLogRecord <- atomically $ readTBQueue logRecords
       case maybeLogRecord of
         Just logRecord -> do
-          putStrLn $ show logRecord
+          T.putStrLn logRecord
           go
         -- Stop the loop when we receive a Nothing.
         Nothing -> pure ()

--- a/src/WebsocketServer.hs
+++ b/src/WebsocketServer.hs
@@ -39,7 +39,6 @@ broadcast =
   let
     send :: Value -> WS.Connection -> IO ()
     send value conn = do
-      -- putStrLn $ "Sending text data ..."
       WS.sendTextData conn (Aeson.encode value)
   in
     Subscription.broadcast send
@@ -83,8 +82,7 @@ keepTalking :: WS.Connection -> IO ()
 keepTalking conn = forever $ do
     -- Note: WS.receiveDataMessage will handle control messages automatically and e.g.
     -- do the closing handshake of the websocket protocol correctly
-    _ <- WS.receiveDataMessage conn
-    putStrLn "bla"
+    WS.receiveDataMessage conn
 
 -- Print the path and headers of the pending request
 printRequest :: WS.PendingConnection -> IO ()

--- a/src/WebsocketServer.hs
+++ b/src/WebsocketServer.hs
@@ -19,6 +19,7 @@ import Prelude hiding (log)
 import System.Random (randomIO)
 
 import qualified Data.Aeson as Aeson
+import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import qualified Network.WebSockets as WS
 import qualified Network.HTTP.Types.URI as Uri
@@ -62,13 +63,13 @@ handleClient conn path core = do
     logRecords = coreLogRecords core
     onConnect = do
       modifyMVar_ state (pure . Subscription.subscribe path uuid conn)
-      log ("Client " ++ (show uuid) ++ " connected, subscribed to " ++ (show path) ++ ".") logRecords
+      log (T.pack $ "Client " ++ (show uuid) ++ " connected, subscribed to " ++ (show path) ++ ".") logRecords
     onDisconnect = do
       modifyMVar_ state (pure . Subscription.unsubscribe path uuid)
-      log ("Client " ++ (show uuid) ++ " disconnected.") logRecords
+      log (T.pack $ "Client " ++ (show uuid) ++ " disconnected.") logRecords
     sendInitialValue = do
       currentValue <- getCurrentValue core path
-      log ("Sending initial value to client: " ++ show currentValue) logRecords
+      log (T.pack $ "Sending initial value to client: " ++ show currentValue) logRecords
       WS.sendTextData conn (Aeson.encode currentValue)
   -- Put the client in the subscription tree and keep the connection open.
   -- Remove it when the connection is closed.


### PR DESCRIPTION
Using putStrLn in a number of concurrent threads leads to garbled output.
We therefore use a TBQueue for log messages as well and have a separate
logging loop that writes them to stdout one after the other leading to
nice logs.