### PR TITLE
Persist the Json data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ cabal.project.local
 # Vim swap files
 *.swp
 *.swo
+icepeak.json

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <img src="https://img.shields.io/badge/license-BSD3-blue.svg" alt="BSD3 Licensed">
 </p>
 
-Icepeak is a fast json document store with push notification support.
+Icepeak is a fast JSON document store with push notification support.
 
 ## Disclaimer
 
@@ -23,6 +23,17 @@ Install with `stack install`
 
 Integration tests are in `/integration-tests`.
 They are stand-alone scripts that can be executed directly, e.g. `./connection_test.py`.
+
+## Usage:
+
+```
+Usage: icepeak [--data-file DATA_FILE]
+
+Available options:
+  --data-file DATA_FILE    File where data is persisted to. Default:
+                           icepeak.json
+  -h,--help                Show this help text
+```
 
 ## Connecting a client
 

--- a/app/Icepeak.hs
+++ b/app/Icepeak.hs
@@ -5,7 +5,7 @@ module Main where
 import Control.Concurrent.Async
 import Control.Exception (try, SomeException)
 import Control.Monad (void)
-import Data.Aeson (eitherDecodeStrict)
+import Data.Aeson (eitherDecodeStrict, Value)
 import Data.ByteString (hGetContents, ByteString)
 import Options.Applicative (execParser)
 import Prelude hiding (log)
@@ -23,7 +23,7 @@ import qualified HttpServer
 import qualified Server
 import qualified WebsocketServer
 
--- Instal SIGTERM and SIGINT handlers to do a graceful exit.
+-- Install SIGTERM and SIGINT handlers to do a graceful exit.
 installHandlers :: Core -> Async () -> IO ()
 installHandlers core serverThread =
   let
@@ -38,30 +38,35 @@ installHandlers core serverThread =
     void $ installHandler Signals.sigTERM
     void $ installHandler Signals.sigINT
 
+
+readValue :: FilePath -> IO Value
+readValue filePath = do
+  eitherEncodedValue <- try $ withFile filePath ReadMode hGetContents
+  case (eitherEncodedValue :: Either SomeException ByteString) of
+      Left exc -> error $ "Failed to read the data from disk: " ++ show exc
+      Right encodedValue -> case eitherDecodeStrict encodedValue of
+        Left msg  -> error $ "Failed to decode the initial data: " ++ show msg
+        Right value -> return value
+
+
 main :: IO ()
 main = do
   config <- execParser configInfo
   -- load the persistent data from disk
   let filePath = configDataFile config
-  eitherEncodedValue <- try $ withFile filePath ReadMode hGetContents
+  value <- readValue filePath
+  core <- Core.newCore value config
+  httpServer <- HttpServer.new core
+  let wsServer = WebsocketServer.acceptConnection core
+  pops <- Async.async $ Core.processOps core
+  upds <- Async.async $ WebsocketServer.processUpdates core
+  serv <- Async.async $ Server.runServer wsServer httpServer
+  logger <- Async.async $ processLogRecords (coreLogRecords core)
+  installHandlers core serv
+  log "System online. ** robot sounds **" (coreLogRecords core)
 
-  case (eitherEncodedValue :: Either SomeException ByteString) of
-      Left exc -> putStrLn $ "Failed to read the data from disk: " ++ show exc
-      Right encodedValue -> case eitherDecodeStrict encodedValue of
-          Left msg  -> error $ "Failed to decode the initial data: " ++ show msg
-          Right value -> do
-              core <- Core.newCore value config
-              httpServer <- HttpServer.new core
-              let wsServer = WebsocketServer.acceptConnection core
-              pops <- Async.async $ Core.processOps core
-              upds <- Async.async $ WebsocketServer.processUpdates core
-              serv <- Async.async $ Server.runServer wsServer httpServer
-              logger <- Async.async $ processLogRecords (coreLogRecords core)
-              installHandlers core serv
-              log "System online. ** robot sounds **" (coreLogRecords core)
-
-              -- TODO: Log exceptions properly (i.e. non-interleaved)
-              void $ Async.wait pops
-              void $ Async.wait upds
-              void $ Async.wait serv
-              void $ Async.wait logger
+  -- TODO: Log exceptions properly (i.e. non-interleaved)
+  void $ Async.wait pops
+  void $ Async.wait upds
+  void $ Async.wait serv
+  void $ Async.wait logger

--- a/app/Icepeak.hs
+++ b/app/Icepeak.hs
@@ -3,13 +3,14 @@ module Main where
 
 import Control.Monad (void)
 import Control.Concurrent.Async
-import Data.Aeson (eitherDecode, Value (..))
+import Data.Aeson (eitherDecodeStrict)
+-- import Data.ByteString.Lazy (hGetContents)
+import Data.ByteString (hGetContents)
 import Options.Applicative (execParser)
 import Prelude hiding (log)
 import System.IO (withFile, IOMode (..))
 
 import qualified Control.Concurrent.Async as Async
-import qualified Data.ByteString.Lazy as BS
 import qualified System.Posix.Signals as Signals
 
 import Config (configInfo, cDataFile)
@@ -39,25 +40,26 @@ installHandlers core serverThread =
 main :: IO ()
 main = do
   config <- execParser configInfo
-  maybeValue <- withFile (cDataFile config) ReadMode BS.hGetContents
   -- load the persistent data from disk
-  -- maybeValue <- BS.readFile "icepeak.json"
+  let filePath = cDataFile config
+  encodedValue <- withFile (cDataFile config) ReadMode hGetContents
 
-  let value = case eitherDecode maybeValue of
-                Left _msg  -> Object mempty
-                Right obj  -> obj
-  core <- Core.newCore value
-  httpServer <- HttpServer.new core
-  let wsServer = WebsocketServer.acceptConnection core
-  pops <- Async.async $ Core.processOps core
-  upds <- Async.async $ WebsocketServer.processUpdates core
-  serv <- Async.async $ Server.runServer wsServer httpServer
-  logger <- Async.async $ processLogRecords (coreLogRecords core)
-  installHandlers core serv
-  log "System online. ** robot sounds **" (coreLogRecords core)
+  case eitherDecodeStrict encodedValue of
+      Left msg  -> error $ "Failed to load the initial data in " ++ filePath ++
+                           ": " ++ msg
+      Right value -> do
+          core <- Core.newCore value
+          httpServer <- HttpServer.new core
+          let wsServer = WebsocketServer.acceptConnection core
+          pops <- Async.async $ Core.processOps core
+          upds <- Async.async $ WebsocketServer.processUpdates core
+          serv <- Async.async $ Server.runServer wsServer httpServer
+          logger <- Async.async $ processLogRecords (coreLogRecords core)
+          installHandlers core serv
+          log "System online. ** robot sounds **" (coreLogRecords core)
 
-  -- TODO: Log exceptions properly (i.e. non-interleaved)
-  void $ Async.wait pops
-  void $ Async.wait upds
-  void $ Async.wait serv
-  void $ Async.wait logger
+          -- TODO: Log exceptions properly (i.e. non-interleaved)
+          void $ Async.wait pops
+          void $ Async.wait upds
+          void $ Async.wait serv
+          void $ Async.wait logger

--- a/app/Icepeak.hs
+++ b/app/Icepeak.hs
@@ -4,6 +4,7 @@ module Main where
 import Control.Monad (void)
 import Control.Concurrent.Async
 import Data.Aeson (eitherDecode, Value (..))
+import Options.Applicative (execParser)
 import Prelude hiding (log)
 import System.IO (withFile, IOMode (..))
 
@@ -11,6 +12,7 @@ import qualified Control.Concurrent.Async as Async
 import qualified Data.ByteString.Lazy as BS
 import qualified System.Posix.Signals as Signals
 
+import Config (configInfo, cDataFile)
 import Core (Core (..))
 import Logger (log, processLogRecords)
 
@@ -36,7 +38,8 @@ installHandlers core serverThread =
 
 main :: IO ()
 main = do
-  maybeValue <- withFile "icepeak.json" ReadMode BS.hGetContents
+  config <- execParser configInfo
+  maybeValue <- withFile (cDataFile config) ReadMode BS.hGetContents
   -- load the persistent data from disk
   -- maybeValue <- BS.readFile "icepeak.json"
 

--- a/icepeak.cabal
+++ b/icepeak.cabal
@@ -26,6 +26,7 @@ library
     , monad-logger >=0.3 && <0.4
     , mtl >=2.2 && <2.3
     , network >=2.6 && <2.7
+    , optparse-applicative >= 0.13 && <0.14
     , random >=1.1 && <1.2
     , scotty >=0.11 && <0.12
     , stm >=2.4 && <2.5
@@ -40,6 +41,7 @@ library
     , websockets >=0.12 && <0.13
     , securemem <0.2
   exposed-modules:
+      Config
       Core
       Guardian
       HttpServer
@@ -68,6 +70,7 @@ executable icepeak
     , monad-logger >=0.3 && <0.4
     , mtl >=2.2 && <2.3
     , network >=2.6 && <2.7
+    , optparse-applicative >= 0.13 && <0.14
     , random >=1.1 && <1.2
     , scotty >=0.11 && <0.12
     , stm >=2.4 && <2.5
@@ -101,6 +104,7 @@ test-suite spec
     , monad-logger >=0.3 && <0.4
     , mtl >=2.2 && <2.3
     , network >=2.6 && <2.7
+    , optparse-applicative >= 0.13 && <0.14
     , random >=1.1 && <1.2
     , scotty >=0.11 && <0.12
     , stm >=2.4 && <2.5

--- a/icepeak.cabal
+++ b/icepeak.cabal
@@ -4,7 +4,7 @@
 
 name:           icepeak
 version:        0.0.1
-synopsis:       Fast JSON store with push notification support
+synopsis:       Icepeak is a fast Json document store with push notification support
 homepage:       https://github.com/channable/icepeak
 license:        BSD3
 license-file:   LICENSE

--- a/icepeak.cabal
+++ b/icepeak.cabal
@@ -21,6 +21,7 @@ library
     , base >=4.8 && <5.0
     , bytestring >=0.10 && <0.11
     , containers >=0.5 && <0.6
+    , directory >= 1.3 && <1.4
     , hashable >=1.2 && <1.3
     , http-types >=0.9 && <0.10
     , monad-logger >=0.3 && <0.4
@@ -65,6 +66,7 @@ executable icepeak
     , base >=4.8 && <5.0
     , bytestring >=0.10 && <0.11
     , containers >=0.5 && <0.6
+    , directory >= 1.3 && <1.4
     , hashable >=1.2 && <1.3
     , http-types >=0.9 && <0.10
     , monad-logger >=0.3 && <0.4
@@ -99,6 +101,7 @@ test-suite spec
     , base >=4.8 && <5.0
     , bytestring >=0.10 && <0.11
     , containers >=0.5 && <0.6
+    , directory >= 1.3 && <1.4
     , hashable >=1.2 && <1.3
     , http-types >=0.9 && <0.10
     , monad-logger >=0.3 && <0.4

--- a/integration-tests/persistence_test.py
+++ b/integration-tests/persistence_test.py
@@ -14,16 +14,14 @@ json2 = {'so': {}}
 json3 = {'so': {'cool': {}}}
 json4 = {'so': {'cool': {}, 'hot': {}}}
 
-def read_after_write_check(url, data, expected_result=None):
-    """
-    First PUT the given `data` to the given `url`.
-    Then make sure we can read the data back from disk.
+icepeak_endpoint = 'http://localhost:3000'
 
-    `expected_result` can be passed if it is different from `data`.
+def read_after_write_check(url_path, data, expected_result):
     """
-    if expected_result is None:
-        expected_result = data
-
+    First PUT the given `data` to the given `url_path`.
+    Then make sure we can read the `expected_result` back from disk.
+    """
+    url = '{}{}?{}'.format(icepeak_endpoint, url_path, auth)
     requests.put(url, json.dumps(data))
 
     with open('../icepeak.json', 'r') as f:
@@ -33,8 +31,8 @@ def read_after_write_check(url, data, expected_result=None):
 
     print 'Successfully wrote and read: {}'.format(data)
 
-read_after_write_check('http://localhost:3000?{}'.format(auth), json1)
-read_after_write_check('http://localhost:3000?{}'.format(auth), json2)
-read_after_write_check('http://localhost:3000?{}'.format(auth), json3)
-read_after_write_check('http://localhost:3000/so?{}'.format(auth), {'cool' : {}}, json3)
-read_after_write_check('http://localhost:3000/so/hot?{}'.format(auth), json1, json4)
+read_after_write_check('', json1, json1)
+read_after_write_check('', json2, json2)
+read_after_write_check('', json3, json3)
+read_after_write_check('/so', {'cool' : {}}, json3)
+read_after_write_check('/so/hot', json1, json4)

--- a/integration-tests/persistence_test.py
+++ b/integration-tests/persistence_test.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python2.7
+"""
+Test that we can read data back from disk after PUTing it.
+"""
+from __future__ import absolute_import, division, unicode_literals
+
+import json
+import requests
+import websocket
+
+auth = 'auth=mS7karSP9QbD2FFdgBk2QmuTna7fJyp7ll0Vg8gnffIBHKILSrusMslucBzMhwO'
+json1 = {}
+json2 = {'so': {}}
+json3 = {'so': {'cool': {}}}
+json4 = {'so': {'cool': {}, 'hot': {}}}
+
+def read_after_write_check(url, data, expected_result=None):
+    """
+    First PUT the given `data` to the given `url`.
+    Then make sure we can read the data back from disk.
+
+    `expected_result` can be passed if it is different from `data`.
+    """
+    if expected_result is None:
+        expected_result = data
+
+    requests.put(url, json.dumps(data))
+
+    with open('../icepeak.json', 'r') as f:
+        on_disk = json.loads(f.read())
+        assert on_disk == expected_result, \
+               'Invalid data. Expected: {}. Got: {}.'.format(expected_result, on_disk)
+
+    print 'Successfully wrote and read: {}'.format(data)
+
+read_after_write_check('http://localhost:3000?{}'.format(auth), json1)
+read_after_write_check('http://localhost:3000?{}'.format(auth), json2)
+read_after_write_check('http://localhost:3000?{}'.format(auth), json3)
+read_after_write_check('http://localhost:3000/so?{}'.format(auth), {'cool' : {}}, json3)
+read_after_write_check('http://localhost:3000/so/hot?{}'.format(auth), json1, json4)

--- a/package.yaml
+++ b/package.yaml
@@ -18,6 +18,7 @@ dependencies:
 - monad-logger >=0.3 && <0.4
 - mtl >=2.2 && <2.3
 - network >=2.6 && <2.7
+- optparse-applicative >= 0.13 && <0.14
 - random >=1.1 && <1.2
 - scotty >=0.11 && <0.12
 - stm >=2.4 && <2.5
@@ -41,6 +42,7 @@ library:
   - -fno-ignore-asserts
   - -funbox-strict-fields
   exposed-modules:
+  - Config
   - Core
   - Guardian
   - HttpServer

--- a/package.yaml
+++ b/package.yaml
@@ -13,6 +13,7 @@ dependencies:
 - base >=4.8 && <5.0
 - bytestring >=0.10 && <0.11
 - containers >=0.5 && <0.6
+- directory >= 1.3 && <1.4
 - hashable >=1.2 && <1.3
 - http-types >=0.9 && <0.10
 - monad-logger >=0.3 && <0.4

--- a/package.yaml
+++ b/package.yaml
@@ -1,6 +1,6 @@
 name: icepeak
 version: '0.0.1'
-synopsis: Fast JSON store with push notification support
+synopsis: Icepeak is a fast Json document store with push notification support
 license: BSD3
 homepage: https://github.com/channable/icepeak
 ghc-options:

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -5,11 +5,11 @@ module Config (
 
 import Data.Semigroup ((<>))
 import Options.Applicative (Parser, ParserInfo, fullDesc, header, help,
-  helper, info, long, metavar, strOption, value, (<**>))
+  helper, info, long, metavar, strOption, value)
 
 -- command-line arguments
 data Config = Config {
-    cDataFile :: FilePath
+    configDataFile :: FilePath
 }
 
 -- Parsing of command-line arguments
@@ -25,6 +25,6 @@ configParser =
 configInfo :: ParserInfo Config
 configInfo = info parser description
   where
-    parser = configParser <**> helper
+    parser = helper <*> configParser
     description = fullDesc <>
       header "Icepeak - Fast Json document store with push notification support."

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -27,4 +27,4 @@ configInfo = info parser description
   where
     parser = configParser <**> helper
     description = fullDesc <>
-      header "Icepeak - Fast JSON document store with push notification support."
+      header "Icepeak - Fast Json document store with push notification support."

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -1,0 +1,30 @@
+module Config (
+  Config (..),
+  configInfo
+) where
+
+import Data.Semigroup ((<>))
+import Options.Applicative (Parser, ParserInfo, fullDesc, header, help,
+  helper, info, long, metavar, strOption, value, (<**>))
+
+-- command-line arguments
+data Config = Config {
+    cDataFile :: FilePath
+}
+
+-- Parsing of command-line arguments
+
+configParser :: Parser Config
+configParser =
+  Config
+    <$> strOption (long "data-file" <>
+                   metavar "DATA_FILE" <>
+                   value "icepeak.json" <>
+                   help "File where data is persisted to. Default: icepeak.json")
+
+configInfo :: ParserInfo Config
+configInfo = info parser description
+  where
+    parser = configParser <**> helper
+    description = fullDesc <>
+      header "Icepeak - Fast JSON document store with push notification support."

--- a/src/Core.hs
+++ b/src/Core.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 module Core
 (
   Core (..), -- TODO: Expose only put for clients.
@@ -112,8 +113,6 @@ processOps core = go Null
             writeTBQueue (coreUpdates core) (Just $ Updated (opPath op) newValue)
           -- persist the updated Json object to disk
           -- TODO: make it configurable how often we do this (like in Redis)
-          putStrLn $ "Applying operation: " ++ show op
-          putStrLn $ "newValue: " ++ show newValue
           writeFile "icepeak.json" (encodeToLazyText newValue)
           go newValue
         Nothing -> do

--- a/src/Core.hs
+++ b/src/Core.hs
@@ -64,9 +64,9 @@ type ServerState = SubscriptionTree UUID WS.Connection
 newServerState :: ServerState
 newServerState = empty
 
-newCore :: IO Core
-newCore = do
-  tvalue <- newTVarIO Null
+newCore :: Value -> IO Core
+newCore value = do
+  tvalue <- newTVarIO value
   tqueue <- newTBQueueIO 256
   tupdates <- newTBQueueIO 256
   tclients <- newMVar newServerState
@@ -112,7 +112,9 @@ processOps core = go Null
             writeTBQueue (coreUpdates core) (Just $ Updated (opPath op) newValue)
           -- persist the updated Json object to disk
           -- TODO: make it configurable how often we do this (like in Redis)
-          writeFile "/tmp/icepeak.json" (encodeToLazyText newValue)
+          putStrLn $ "Applying operation: " ++ show op
+          putStrLn $ "newValue: " ++ show newValue
+          writeFile "icepeak.json" (encodeToLazyText newValue)
           go newValue
         Nothing -> do
           -- Stop the loop when we receive a Nothing.

--- a/src/Core.hs
+++ b/src/Core.hs
@@ -21,8 +21,10 @@ import Control.Concurrent.STM.TBQueue (TBQueue, newTBQueueIO, readTBQueue, write
 import Control.Concurrent.STM.TVar (TVar, newTVarIO, writeTVar, readTVar)
 import Control.Monad (unless)
 import Data.Aeson (Value (..))
+import Data.Aeson.Text (encodeToLazyText)
+import Data.Text.Lazy.IO (writeFile)
 import Data.UUID (UUID)
-import Prelude hiding (log)
+import Prelude hiding (log, writeFile)
 import Store (Path)
 import Subscription (SubscriptionTree, empty)
 
@@ -108,6 +110,9 @@ processOps core = go Null
           atomically $ do
             writeTVar (coreCurrentValue core) newValue
             writeTBQueue (coreUpdates core) (Just $ Updated (opPath op) newValue)
+          -- persist the updated Json object to disk
+          -- TODO: make it configurable how often we do this (like in Redis)
+          writeFile "/tmp/icepeak.json" (encodeToLazyText newValue)
           go newValue
         Nothing -> do
           -- Stop the loop when we receive a Nothing.


### PR DESCRIPTION
This PR adds a basic persistence mechanism:

- After every operation is applied to the internal data representation the data is also written to disk
- Data is simply written to a file as plain-text Json
- The user can specify the location of the file
- On startup icepeak will read back the data from disk

We don't focus on performance here or worry about the (small) data loss possibility due to the HTTP loop and the operations loop not being synchronized. The goal is simply to get icepeak into a usable state.