### PR TITLE
Notify subscribers of changes to child nodes

### DIFF
--- a/server/integration-tests/listener.html
+++ b/server/integration-tests/listener.html
@@ -5,18 +5,41 @@
 <style>
   body { font-family: 'Helvetica', 'Arial', sans-serif; }
 </style>
-<p>
+<fieldset>
+  <legend>Configuration</legend>
+  URL: <input id="url" type="url" value="ws://localhost:3000"/>
+  <button id="reload" type="button">Reload</button>
+</fieldset>
+<fieldset>
+  <legend>Status</legend>
   <!-- we set the status dynamically from the websocket data -->
-  Status: <span id="status"></span>
-</p>
+  <pre id="status"></pre>
+</fieldset>
 
 <script>
-  var webSocket = new WebSocket("ws://localhost:3000");
-  webSocket.onmessage = function (event) {
-    var msg = JSON.parse(event.data);
-    console.log('Received data: ' + event.data);
-    var status = document.getElementById("status");
-    console.log('status: ' + status);
-    status.textContent = JSON.stringify(msg);
-  }
+  (function() {
+    var urlField = document.getElementById("url");
+    var reloadButton = document.getElementById("reload");
+    var statusField = document.getElementById("status");
+
+    var webSocket = null;
+    var reload = function() {
+      if (webSocket !== null) {
+        webSocket.close();
+      }
+      webSocket = new WebSocket(urlField.value);
+      webSocket.addEventListener("message", function (event) {
+        var msg = JSON.parse(event.data);
+        console.log('Received data: ' + event.data);
+        console.log('status: ' + status);
+        statusField.textContent = JSON.stringify(msg, null, 4);
+      });
+    };
+
+    reloadButton.addEventListener("click", function() {
+      reload();
+    });
+
+    reload();
+  })();
 </script>

--- a/server/src/Subscription.hs
+++ b/server/src/Subscription.hs
@@ -19,13 +19,13 @@ import Data.Aeson (Value)
 import Data.Foldable (traverse_)
 import Data.HashMap.Strict (HashMap)
 import Data.Hashable (Hashable)
-import Data.List (inits)
 import Data.Maybe (fromMaybe)
 import Data.Monoid ((<>))
 import Data.Text (Text)
 
 import qualified Control.Concurrent.Async as Async
 import qualified Data.HashMap.Strict as HashMap
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as Text
 
 import qualified Store
@@ -71,21 +71,26 @@ unsubscribe path subid (SubscriptionTree here inner) =
 -- subvalue at the path that they are subscribed to.
 broadcast :: (v -> Value -> IO ()) -> [Text] -> Value -> SubscriptionTree k v -> IO ()
 broadcast f path value tree =
-  Async.mapConcurrently_ (uncurry f) (execWriter (broadcast' path value tree))
+  let notifications = broadcast' path value tree
+  in Async.mapConcurrently_ (uncurry f) notifications
 
--- Like broadcast, but pure.
-broadcast' :: [Text] -> Value -> SubscriptionTree k v -> Writer [(v, Value)] ()
-broadcast' path value tree = do
+-- Like broadcast, but return a list of notifications rather than invoking an
+-- effect on each of them.
+broadcast' :: [Text] -> Value -> SubscriptionTree k v -> [(v, Value)]
+broadcast' path value tree = execWriter $ do
   broadcastParents path value tree
-  broadcastChildren path value tree
+  broadcastSelfAndChildren path value tree
 
+-- Subscribers of parents of the node being updated need to be notified. This
+-- also includes parents that were not present prior to the update.
 broadcastParents
   :: forall k v
    . [Text]
   -> Value
   -> SubscriptionTree k v
   -> Writer [(v, Value)] ()
-broadcastParents path value root = traverse_ onInit (inits path)
+broadcastParents path value root =
+  traverse_ onInit (NE.init (NE.inits path))
   where
     onInit :: [Text] -> Writer [(v, Value)] ()
     onInit subpath =
@@ -97,26 +102,29 @@ broadcastParents path value root = traverse_ onInit (inits path)
     findHere (p : ps) (SubscriptionTree _ inner) =
       fromMaybe HashMap.empty . fmap (findHere ps) . HashMap.lookup p $ inner
 
-broadcastChildren
+-- Subscribers of children of the node being updated need to be notified. This
+-- also includes children that were not present prior to the update. Also notify
+-- subscribers of the node itself.
+broadcastSelfAndChildren
   :: [Text]
   -> Value
   -> SubscriptionTree k v
   -> Writer [(v, Value)] ()
-broadcastChildren path value (SubscriptionTree here inner) = do
+broadcastSelfAndChildren path value (SubscriptionTree here inner) = do
   case path of
     [] -> do
       -- When the path is empty, all subscribers that are "here" or at a deeper
       -- level should receive a notification.
       -- We broadcast concurrently since all updates are independent of each other
       traverse_ (\v -> tell [(v, value)]) here
-      let broadcastInner key = broadcastChildren [] (Store.lookupOrNull [key] value)
+      let broadcastInner key = broadcastSelfAndChildren [] (Store.lookupOrNull [key] value)
       void $ HashMap.traverseWithKey broadcastInner inner
 
     key : pathTail -> case HashMap.lookup key inner of
       Nothing -> pure ()
       -- TODO: Extract the inner thing from the value as well; the client is not
       -- subscribed to the top-level thing after all.
-      Just subs -> broadcastChildren pathTail (Store.lookupOrNull [key] value) subs
+      Just subs -> broadcastSelfAndChildren pathTail (Store.lookupOrNull [key] value) subs
 
 -- Show subscriptions, for debugging purposes.
 showTree :: Show k => SubscriptionTree k v -> String

--- a/server/src/Subscription.hs
+++ b/server/src/Subscription.hs
@@ -83,12 +83,7 @@ broadcast' path value tree = execWriter $ do
 
 -- Subscribers of parents of the node being updated need to be notified. This
 -- also includes parents that were not present prior to the update.
-broadcastParents
-  :: forall k v
-   . [Text]
-  -> Value
-  -> SubscriptionTree k v
-  -> Writer [(v, Value)] ()
+broadcastParents :: forall k v. [Text] -> Value -> SubscriptionTree k v -> Writer [(v, Value)] ()
 broadcastParents path value root =
   traverse_ onInit (NE.init (NE.inits path))
   where
@@ -105,11 +100,7 @@ broadcastParents path value root =
 -- Subscribers of children of the node being updated need to be notified. This
 -- also includes children that were not present prior to the update. Also notify
 -- subscribers of the node itself.
-broadcastSelfAndChildren
-  :: [Text]
-  -> Value
-  -> SubscriptionTree k v
-  -> Writer [(v, Value)] ()
+broadcastSelfAndChildren :: [Text] -> Value -> SubscriptionTree k v -> Writer [(v, Value)] ()
 broadcastSelfAndChildren path value (SubscriptionTree here inner) = do
   case path of
     [] -> do

--- a/server/src/WebsocketServer.hs
+++ b/server/src/WebsocketServer.hs
@@ -37,8 +37,8 @@ newUUID = randomIO
 broadcast :: [Text] -> Value -> ServerState -> IO ()
 broadcast =
   let
-    send :: Value -> WS.Connection -> IO ()
-    send value conn = do
+    send :: WS.Connection -> Value -> IO ()
+    send conn value = do
       WS.sendTextData conn (Aeson.encode value)
   in
     Subscription.broadcast send

--- a/server/tests/SubscriptionTreeSpec.hs
+++ b/server/tests/SubscriptionTreeSpec.hs
@@ -3,7 +3,6 @@
 
 module SubscriptionTreeSpec (spec) where
 
-import Control.Monad.Writer (execWriter)
 import Data.List (sortOn)
 import Test.Hspec (Spec, describe, it, shouldBe)
 import Test.Hspec.QuickCheck (prop)
@@ -90,7 +89,7 @@ spec = do
         value_foo_bar = AE.Null
         value_baz = AE.object []
 
-        broadcast'' path = sortOn fst . execWriter $ broadcast' path value root
+        broadcast'' path = sortOn fst $ broadcast' path value root
 
       it "notifies everyone on root updates" $ do
         broadcast'' []

--- a/server/tests/SubscriptionTreeSpec.hs
+++ b/server/tests/SubscriptionTreeSpec.hs
@@ -3,6 +3,7 @@
 
 module SubscriptionTreeSpec (spec) where
 
+import Control.Monad.Writer (execWriter)
 import Data.List (sortOn)
 import Test.Hspec (Spec, describe, it, shouldBe)
 import Test.Hspec.QuickCheck (prop)
@@ -89,8 +90,10 @@ spec = do
         value_foo_bar = AE.Null
         value_baz = AE.object []
 
+        broadcast'' path = sortOn fst . execWriter $ broadcast' path value root
+
       it "notifies everyone on root updates" $ do
-        sortOn fst (broadcast' [] value root)
+        broadcast'' []
           `shouldBe` [ (conn1, value)
                      , (conn2, value_foo)
                      , (conn3, value_foo_bar)
@@ -98,14 +101,14 @@ spec = do
                      ]
 
       it "notifies parents and children about updates" $ do
-        sortOn fst (broadcast' ["foo"] value root)
+        broadcast'' ["foo"]
           `shouldBe` [ (conn1, value)
                      , (conn2, value_foo)
                      , (conn3, value_foo_bar)
                      ]
 
       it "notifies parents and children about updates" $ do
-        sortOn fst (broadcast' ["foo", "bar"] value root)
+        broadcast'' ["foo", "bar"]
           `shouldBe` [ (conn1, value)
                      , (conn2, value_foo)
                      , (conn3, value_foo_bar)


### PR DESCRIPTION
Fixes #5.

Also adds more functionality to `listener.html`, that is useful for debugging.
Also adds a pure variant of `broadcast`, which returns a list of notifications instead of sending the notifications.
