### PR TITLE
Implement journaling

### DIFF
--- a/docs/data-management.md
+++ b/docs/data-management.md
@@ -1,0 +1,72 @@
+# Data representation
+
+Icepeak is a key-value store for JSON data. In memory, the state is represented
+as a `Data.Aeson.Value`, on disk, it is serialized as the textual JSON
+representation.
+
+# Modifications
+
+Icepeak supports two kinds of modification operations:
+
+- `Put` writes a JSON value to a given path in the JSON structure.
+
+  - If the path descends into a JSON value that is not an object, that value is
+    replaced by an object that just contains the newly created path.
+  - If a value along the path is already an object, the field specified by the
+    path is added to it.
+
+- `Delete` removes a JSON value at a given path.
+
+  - If the path does not exist, nothing happens.
+  - If the path refers to a field in an object, that field is removed from the
+    object.
+
+# Atomic writes
+
+To make sure an interrupted write does not corrupt the database, the new value
+is first written to a file with the same name as the data file but with the
+extension `.new` appended. For example, if the data is stored in `icepeak.json`,
+the new data will first be written to `icepeak.json.new`.
+
+Only then, `icepeak.json.new` is renamed to `icepeak.json`, thereby overwriting
+it. POSIX guarantees that this rename operation is atomic.
+
+# Journaling
+
+Icepeak optionally supports journaling in order to prevent data loss.
+
+Every operation is written to the journal before it is applied to the in-memory
+representation. Whenever the in-memory value has been persisted to disk, the
+journal is cleared.
+
+In the case of a hard crash, Icepeak uses the journal on the next startup to
+replay any operations that have not yet been persisted in the on-disk value.
+
+## Journal file format
+
+The journal is held in a file with the same name as the data file but with
+`.journal` appended. For example, if the data is stored in `icepeak.json`, the
+journal is kept in `icepeak.json.journal`.
+
+The journal is a simple text based format where every line (separated by `\n`)
+represents one operation, encoded in JSON without any unnecessary whitespace. In
+particular, the JSON representation of an operation does not contain new line
+characters. New line characters occurring the serialized text are escaped.
+
+The two kinds of operations are encoded as follows:
+
+- A `Put` operation writing the JSON value `someval` to the path `somepath` is encoded as
+
+  ```
+  {"op":"put","path":somepath,"value":someval}
+  ```
+
+- A `Delete` operation deleting the path `somepath` is encoded as
+
+  ```
+  {"op":"del","path":somepath}
+  ```
+
+The paths are encoded as JSON arrays of the individual components. The path
+`/this/is/a/path` is encoded as `["this","is","a","path"]`. The root path is
+represented by the empty array `[]`.

--- a/docs/data-management.md
+++ b/docs/data-management.md
@@ -21,6 +21,10 @@ Icepeak supports two kinds of modification operations:
   - If the path refers to a field in an object, that field is removed from the
     object.
 
+Note that in the current implementation, HTTP requests to the REST API return
+before the modification has been applied to the data. This is because updates
+are delegated to a different thread than the HTTP request.
+
 # Atomic writes
 
 To make sure an interrupted write does not corrupt the database, the new value
@@ -64,7 +68,7 @@ The two kinds of operations are encoded as follows:
 - A `Delete` operation deleting the path `somepath` is encoded as
 
   ```
-  {"op":"del","path":somepath}
+  {"op":"delete","path":somepath}
   ```
 
 The paths are encoded as JSON arrays of the individual components. The path

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -24,3 +24,4 @@ cabal.project.local
 *.swp
 *.swo
 icepeak.json
+icepeak.json.journal

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -25,3 +25,4 @@ cabal.project.local
 *.swo
 icepeak.json
 icepeak.json.journal
+icepeak.json.new

--- a/server/app/Icepeak/Main.hs
+++ b/server/app/Icepeak/Main.hs
@@ -3,11 +3,12 @@
 module Main where
 
 import Control.Concurrent.Async
+import Control.Exception (fromException, AsyncException)
 import Control.Monad (forM, void, when)
 import Data.Foldable (forM_)
 import Data.Semigroup ((<>))
+import Data.Text (Text)
 import Options.Applicative (execParser)
-import Prelude hiding (log)
 import System.Environment (getEnvironment)
 
 import qualified Control.Concurrent.Async as Async
@@ -18,12 +19,13 @@ import qualified System.Posix.Signals as Signals
 
 import Config (Config (..), configInfo)
 import Core (Core (..))
-import Logger (log, processLogRecords, LogQueue)
+import Logger (Logger, postLog)
 
 import qualified Core
 import qualified HttpServer
 import qualified Server
 import qualified WebsocketServer
+import qualified Logger
 import qualified Metrics
 import qualified MetricsServer
 
@@ -32,7 +34,7 @@ installHandlers :: Core -> Async () -> IO ()
 installHandlers core serverThread =
   let
     handle = do
-      log "\nTermination sequence initiated ..." (coreLogRecords core)
+      postLog (coreLogger core) "\nTermination sequence initiated ..."
       Core.postQuit core
       Async.cancel serverThread
     handler = Signals.CatchOnce handle
@@ -48,13 +50,21 @@ main = do
   env <- getEnvironment
   config <- execParser (configInfo env)
 
+  -- start logging as early as possible
+  logger <- Logger.newLogger (fromIntegral $ configQueueCapacity config)
+  loggerThread <- Async.async $ Logger.processLogRecords logger
+
   -- setup metrics if enabled
   icepeakMetrics <- forM (configMetricsEndpoint config) $ const $ do
     void $ Prometheus.register Prometheus.Metric.GHC.ghcMetrics
     Metrics.createAndRegisterIcepeakMetrics
 
-  eitherCore <- Core.newCore config icepeakMetrics
+  eitherCore <- Core.newCore config logger icepeakMetrics
   either putStrLn runCore eitherCore
+
+  -- only stop logging when everything else has stopped
+  Logger.postStop logger
+  Async.wait loggerThread
 
 runCore :: Core -> IO ()
 runCore core = do
@@ -67,44 +77,49 @@ runCore core = do
   sync <- Async.async $ Core.runSyncTimer core
   upds <- Async.async $ WebsocketServer.processUpdates core
   serv <- Async.async $ Server.runServer wsServer httpServer
-  logger <- Async.async $ processLogRecords (coreLogRecords core)
   metrics <- Async.async
     $ forM_ (configMetricsEndpoint config) MetricsServer.runMetricsServer
   installHandlers core serv
-  logAuthSettings config (coreLogRecords core)
-  logQueueSettings config (coreLogRecords core)
-  logSyncSettings config (coreLogRecords core)
-  log "System online. ** robot sounds **" (coreLogRecords core)
+  logAuthSettings config (coreLogger core)
+  logQueueSettings config (coreLogger core)
+  logSyncSettings config (coreLogger core)
+  postLog (coreLogger core) "System online. ** robot sounds **"
 
-  -- TODO: Log exceptions properly (i.e. non-interleaved)
-  void $ Async.wait pops
-  void $ Async.wait upds
-  void $ Async.wait serv
-  void $ Async.wait logger
+  waitLog "core" (coreLogger core) pops
+  waitLog "web sockets server" (coreLogger core) upds
+  waitLog "http server" (coreLogger core) serv
   -- kill auxiliary threads when the main threads ended
   Async.cancel metrics
   Async.cancel sync
 
-logAuthSettings :: Config -> LogQueue -> IO ()
-logAuthSettings cfg queue
+-- | Wait for an Async computation to exit and log unexpected exceptions.
+waitLog :: Text -> Logger -> Async () -> IO ()
+waitLog name logger action = waitCatch action >>= handleLog where
+  handleLog (Left exc)
+    | Just (_ :: AsyncException) <- fromException exc = pure ()
+    | otherwise = Logger.postLog logger $ name <> " stopped with an exception: " <> Text.pack (show exc)
+  handleLog (Right _) = pure ()
+
+logAuthSettings :: Config -> Logger -> IO ()
+logAuthSettings cfg logger
   | configEnableJwtAuth cfg = case configJwtSecret cfg of
-      Just _ -> log "JWT authorization enabled and secret provided, tokens will be verified." queue
-      Nothing -> log "JWT authorization enabled but no secret provided, tokens will NOT be verified." queue
+      Just _ -> postLog logger "JWT authorization enabled and secret provided, tokens will be verified."
+      Nothing -> postLog logger "JWT authorization enabled but no secret provided, tokens will NOT be verified."
   | otherwise = case configJwtSecret cfg of
-      Just _ -> log "WARNING a JWT secret has been provided, but JWT authorization is disabled." queue
-      Nothing -> log "JWT authorization disabled." queue
+      Just _ -> postLog logger "WARNING a JWT secret has been provided, but JWT authorization is disabled."
+      Nothing -> postLog logger "JWT authorization disabled."
 
-logQueueSettings :: Config -> LogQueue -> IO ()
-logQueueSettings cfg queue =
-  log ("Queue capacity is set to " <> Text.pack (show (configQueueCapacity cfg)) <> ".") queue
+logQueueSettings :: Config -> Logger -> IO ()
+logQueueSettings cfg logger =
+  postLog logger ("Queue capacity is set to " <> Text.pack (show (configQueueCapacity cfg)) <> ".")
 
-logSyncSettings :: Config -> LogQueue -> IO ()
-logSyncSettings cfg queue = case configSyncIntervalMicroSeconds cfg of
+logSyncSettings :: Config -> Logger -> IO ()
+logSyncSettings cfg logger = case configSyncIntervalMicroSeconds cfg of
   Nothing -> do
-    log "Sync: Persisting after every modification" queue
+    postLog logger "Sync: Persisting after every modification"
     when (configEnableJournaling cfg) $ do
-      log "Journaling has no effect when periodic syncing is disabled" queue
+      postLog logger "Journaling has no effect when periodic syncing is disabled"
   Just musecs -> do
-    log ("Sync: every " <> Text.pack (show musecs) <> " microseconds.") queue
+    postLog logger ("Sync: every " <> Text.pack (show musecs) <> " microseconds.")
     when (configEnableJournaling cfg) $ do
-      log "Journaling enabled" queue
+      postLog logger "Journaling enabled"

--- a/server/app/Icepeak/Main.hs
+++ b/server/app/Icepeak/Main.hs
@@ -3,7 +3,7 @@
 module Main where
 
 import Control.Concurrent.Async
-import Control.Monad (forM, void)
+import Control.Monad (forM, void, when)
 import Data.Foldable (forM_)
 import Data.Semigroup ((<>))
 import Options.Applicative (execParser)
@@ -100,5 +100,11 @@ logQueueSettings cfg queue =
 
 logSyncSettings :: Config -> LogQueue -> IO ()
 logSyncSettings cfg queue = case configSyncIntervalMicroSeconds cfg of
-  Nothing -> log "Sync: Persisting after every modification" queue
-  Just musecs -> log ("Sync: every " <> Text.pack (show musecs) <> " microseconds.") queue
+  Nothing -> do
+    log "Sync: Persisting after every modification" queue
+    when (configEnableJournaling cfg) $ do
+      log "Journaling has no effect when periodic syncing is disabled" queue
+  Just musecs -> do
+    log ("Sync: every " <> Text.pack (show musecs) <> " microseconds.") queue
+    when (configEnableJournaling cfg) $ do
+      log "Journaling enabled" queue

--- a/server/app/Icepeak/Main.hs
+++ b/server/app/Icepeak/Main.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 module Main where
 
-import Control.Concurrent.Async
+import Control.Concurrent.Async (Async)
 import Control.Exception (fromException, AsyncException)
 import Control.Monad (forM, void, when)
 import Data.Foldable (forM_)
@@ -94,7 +94,7 @@ runCore core = do
 
 -- | Wait for an Async computation to exit and log unexpected exceptions.
 waitLog :: Text -> Logger -> Async () -> IO ()
-waitLog name logger action = waitCatch action >>= handleLog where
+waitLog name logger action = Async.waitCatch action >>= handleLog where
   handleLog (Left exc)
     | Just (_ :: AsyncException) <- fromException exc = pure ()
     | otherwise = Logger.postLog logger $ name <> " stopped with an exception: " <> Text.pack (show exc)

--- a/server/integration-tests/data-survives-crash.sh
+++ b/server/integration-tests/data-survives-crash.sh
@@ -1,0 +1,49 @@
+#/bin/bash
+
+if [ ! -f "stack.yaml" ]; then
+    echo "Run test in server package directory"
+    exit 1
+fi
+
+########## Preparations
+stack build
+DATA_FILE=`mktemp`
+echo '{}' > "$DATA_FILE"
+
+########## 1st Pass
+stack exec -- icepeak --data-file="$DATA_FILE" --sync-interval 60s --journaling > /dev/null &
+ICEPEAK_PID=$!
+echo "Icepeak started PID=$ICEPEAK_PID"
+sleep 1
+echo "writing data to /foo/b"
+curl -X PUT -d '456' localhost:3000/foo/b
+echo "writing data to /foo/a"
+VALUE_FOO_A="123"
+curl -X PUT -d "$VALUE_FOO_A" localhost:3000/foo/a
+echo "Killing icepeak"
+kill -9 $ICEPEAK_PID
+wait $ICEPEAK_PID
+sleep 1
+
+########## 2nd PASS
+stack exec -- icepeak --data-file="$DATA_FILE" --sync-interval 60s --journaling > /dev/null &
+ICEPEAK_PID=$!
+echo "Icepeak started PID=$ICEPEAK_PID"
+sleep 1
+echo "reading data from /foo/a"
+RESULT=`curl -sS localhost:3000/foo/a`
+kill $ICEPEAK_PID
+wait $ICEPEAK_PID
+
+########## Cleanup
+rm "$DATA_FILE"
+rm "$DATA_FILE.journal"
+
+########## Evaluation
+if [ "$RESULT" -eq "$VALUE_FOO_A" ]; then
+    echo "PASSED"
+    exit 0
+else
+    echo "FAILED"
+    exit 1
+fi

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -57,6 +57,7 @@ library:
   - Logger
   - Metrics
   - MetricsServer
+  - Persistence
   - Server
   - Store
   - Subscription

--- a/server/src/Core.hs
+++ b/server/src/Core.hs
@@ -23,7 +23,7 @@ import Control.Concurrent.MVar (MVar, newMVar)
 import Control.Concurrent.STM (atomically)
 import Control.Concurrent.STM.TBQueue (TBQueue, newTBQueueIO, readTBQueue, writeTBQueue, isFullTBQueue)
 import Control.Concurrent.STM.TVar (TVar, newTVarIO)
-import Control.Monad (forever, unless, when)
+import Control.Monad (forever, unless)
 import Control.Monad.IO.Class
 import Data.Aeson (Value (..))
 import Data.Foldable (forM_)
@@ -143,7 +143,8 @@ runCommandLoop core = go
         Modify op -> do
           Persistence.apply op (coreCurrentValue core)
           postUpdate (Store.modificationPath op) core
-          when (not $ periodicSyncingEnabled $ coreConfig core) $
+          -- when periodic syncing is disabled, data is persisted after every modification
+          unless (periodicSyncingEnabled $ coreConfig core) $
             Persistence.sync (coreCurrentValue core)
           go
         Sync -> do

--- a/server/src/HttpServer.hs
+++ b/server/src/HttpServer.hs
@@ -12,6 +12,7 @@ import qualified Network.Wai as Wai
 import JwtMiddleware (jwtMiddleware)
 import Core (Core (..), EnqueueResult (..))
 import Config (Config (..))
+import qualified Store
 import qualified Core
 import qualified Metrics
 
@@ -33,12 +34,12 @@ new core =
     put (regex "^") $ do
       path <- Wai.pathInfo <$> request
       value <- jsonData
-      result <- liftIO $ Core.tryEnqueueCommand (Core.Modify $ Core.Put path value) core
+      result <- liftIO $ Core.tryEnqueueCommand (Core.Modify $ Store.Put path value) core
       buildResponse result
 
     delete (regex "^") $ do
       path <- Wai.pathInfo <$> request
-      result <- liftIO $ Core.tryEnqueueCommand (Core.Modify $ Core.Delete path) core
+      result <- liftIO $ Core.tryEnqueueCommand (Core.Modify $ Store.Delete path) core
       buildResponse result
 
 buildResponse :: EnqueueResult -> ActionM ()

--- a/server/src/Logger.hs
+++ b/server/src/Logger.hs
@@ -22,9 +22,7 @@ import qualified Data.Text.IO as T
 type LogRecord = Text
 type LogQueue = TBQueue LogCommand
 
-data Logger = Logger
-  { loggerQueue :: LogQueue
-  }
+data Logger = Logger { loggerQueue :: LogQueue }
 
 data LogCommand = LogRecord LogRecord | LogStop
   deriving (Eq, Ord, Show, Read)
@@ -57,5 +55,5 @@ processLogRecords logger = go
         LogRecord logRecord -> do
           T.putStrLn logRecord
           go
-        -- Stop the loop when we receive a Nothing.
+        -- stop the loop when asked so
         LogStop -> pure ()

--- a/server/src/Logger.hs
+++ b/server/src/Logger.hs
@@ -1,36 +1,52 @@
 module Logger
 (
+  Logger,
   LogRecord,
   LogQueue,
-  log,
+  newLogger,
+  postLog,
+  postStop,
   processLogRecords
 )
 where
 
 import Control.Monad (unless)
 import Control.Concurrent.STM (atomically)
-import Control.Concurrent.STM.TBQueue (TBQueue, readTBQueue, writeTBQueue, isFullTBQueue)
+import Control.Concurrent.STM.TBQueue (TBQueue, newTBQueue, readTBQueue, writeTBQueue, isFullTBQueue)
 import Data.Text (Text)
 import Prelude hiding (log)
 
 import qualified Data.Text.IO as T
 
 type LogRecord = Text
-type LogQueue = TBQueue (Maybe LogRecord)
+type LogQueue = TBQueue LogCommand
 
-log :: LogRecord -> LogQueue -> IO ()
-log record logRecords = atomically $ do
-  isFull <- isFullTBQueue logRecords
-  unless isFull $ writeTBQueue logRecords (Just record)
+data Logger = Logger
+  { loggerQueue :: LogQueue
+  }
 
-processLogRecords :: LogQueue -> IO ()
-processLogRecords logRecords = go
+data LogCommand = LogRecord LogRecord | LogStop
+  deriving (Eq, Ord, Show, Read)
+
+newLogger :: Int -> IO Logger
+newLogger queueSize = Logger <$> atomically (newTBQueue queueSize)
+
+postLog :: Logger -> LogRecord -> IO ()
+postLog logger record = atomically $ do
+  isFull <- isFullTBQueue (loggerQueue logger)
+  unless isFull $ writeTBQueue (loggerQueue logger) (LogRecord record)
+
+postStop :: Logger -> IO ()
+postStop logger = atomically $ writeTBQueue (loggerQueue logger) LogStop
+
+processLogRecords :: Logger -> IO ()
+processLogRecords logger = go
   where
     go = do
-      maybeLogRecord <- atomically $ readTBQueue logRecords
-      case maybeLogRecord of
-        Just logRecord -> do
+      cmd <- atomically $ readTBQueue (loggerQueue logger)
+      case cmd of
+        LogRecord logRecord -> do
           T.putStrLn logRecord
           go
         -- Stop the loop when we receive a Nothing.
-        Nothing -> pure ()
+        LogStop -> pure ()

--- a/server/src/Metrics.hs
+++ b/server/src/Metrics.hs
@@ -16,6 +16,7 @@ countHttpRequest method status = withLabel (BS8.unpack method, show $ Http.statu
 data IcepeakMetrics = IcepeakMetrics
   { icepeakMetricsRequestCounter  :: Metric HttpRequestCounter
   , icepeakMetricsDataSize        :: Metric Gauge
+  , icepeakMetricsJournalSize     :: Metric Gauge
   , icepeakMetricsDataWritten     :: Metric Counter
   , icepeakMetricsJournalWritten  :: Metric Counter
   , icepeakMetricsSubscriberCount :: Metric Gauge
@@ -25,6 +26,7 @@ createAndRegisterIcepeakMetrics :: IO IcepeakMetrics
 createAndRegisterIcepeakMetrics = IcepeakMetrics
   <$> registerIO (vector ("method", "status") requestCounter)
   <*> registerIO (gauge (Info "icepeak_data_size" "Size of data file in bytes."))
+  <*> registerIO (gauge (Info "icepeak_journal_size" "Size of journal file in bytes."))
   <*> registerIO (counter (Info "icepeak_data_written" "Total number of bytes written so far."))
   <*> registerIO (counter (Info "icepeak_journal_written" "Total number of bytes written to the journal so far."))
   <*> registerIO (gauge (Info "icepeak_subscriber_count" "Number of websocket subscriber connections."))
@@ -37,6 +39,9 @@ notifyRequest method status = countHttpRequest method status . icepeakMetricsReq
 
 setDataSize :: Real a => a -> IcepeakMetrics -> IO ()
 setDataSize val = setGauge (realToFrac val) . icepeakMetricsDataSize
+
+setJournalSize :: Real a => a -> IcepeakMetrics -> IO ()
+setJournalSize val = setGauge (realToFrac val) . icepeakMetricsJournalSize
 
 incrementDataWritten :: Real a => a -> IcepeakMetrics -> IO ()
 incrementDataWritten val = void . addCounter (realToFrac val) . icepeakMetricsDataWritten

--- a/server/src/Metrics.hs
+++ b/server/src/Metrics.hs
@@ -17,6 +17,7 @@ data IcepeakMetrics = IcepeakMetrics
   { icepeakMetricsRequestCounter  :: Metric HttpRequestCounter
   , icepeakMetricsDataSize        :: Metric Gauge
   , icepeakMetricsDataWritten     :: Metric Counter
+  , icepeakMetricsJournalWritten  :: Metric Counter
   , icepeakMetricsSubscriberCount :: Metric Gauge
   }
 
@@ -25,6 +26,7 @@ createAndRegisterIcepeakMetrics = IcepeakMetrics
   <$> registerIO (vector ("method", "status") requestCounter)
   <*> registerIO (gauge (Info "icepeak_data_size" "Size of data file in bytes."))
   <*> registerIO (counter (Info "icepeak_data_written" "Total number of bytes written so far."))
+  <*> registerIO (counter (Info "icepeak_journal_written" "Total number of bytes written to the journal so far."))
   <*> registerIO (gauge (Info "icepeak_subscriber_count" "Number of websocket subscriber connections."))
   where
     requestCounter = counter (Info "icepeak_http_requests"
@@ -38,6 +40,9 @@ setDataSize val = setGauge (realToFrac val) . icepeakMetricsDataSize
 
 incrementDataWritten :: Real a => a -> IcepeakMetrics -> IO ()
 incrementDataWritten val = void . addCounter (realToFrac val) . icepeakMetricsDataWritten
+
+incrementJournalWritten :: Real a => a -> IcepeakMetrics -> IO ()
+incrementJournalWritten val = void . addCounter (realToFrac val) . icepeakMetricsJournalWritten
 
 incrementSubscribers :: IcepeakMetrics -> IO ()
 incrementSubscribers = incGauge . icepeakMetricsSubscriberCount

--- a/server/src/Metrics.hs
+++ b/server/src/Metrics.hs
@@ -26,9 +26,11 @@ createAndRegisterIcepeakMetrics :: IO IcepeakMetrics
 createAndRegisterIcepeakMetrics = IcepeakMetrics
   <$> registerIO (vector ("method", "status") requestCounter)
   <*> registerIO (gauge (Info "icepeak_data_size" "Size of data file in bytes."))
-  <*> registerIO (gauge (Info "icepeak_journal_size" "Size of journal file in bytes."))
+  <*> registerIO (gauge (Info "icepeak_journal_size_bytes"
+                              "Size of journal file in bytes."))
   <*> registerIO (counter (Info "icepeak_data_written" "Total number of bytes written so far."))
-  <*> registerIO (counter (Info "icepeak_journal_written" "Total number of bytes written to the journal so far."))
+  <*> registerIO (counter (Info "icepeak_journal_written_bytes_total"
+                                "Total number of bytes written to the journal so far."))
   <*> registerIO (gauge (Info "icepeak_subscriber_count" "Number of websocket subscriber connections."))
   where
     requestCounter = counter (Info "icepeak_http_requests"

--- a/server/src/Persistence.hs
+++ b/server/src/Persistence.hs
@@ -1,0 +1,92 @@
+{-| This module abstracts over the details of persisting the value. Journaling is
+  also handled here, if enabled. -}
+module Persistence
+  ( PersistentValue
+  , PersistenceConfig (..)
+  , getValue
+  , apply
+  , load
+  , sync
+  ) where
+
+import           Control.Concurrent.STM
+import           Control.Exception
+import           Control.Monad.Except
+import qualified Data.Aeson                  as Aeson
+import qualified Data.ByteString             as SBS
+import qualified Data.ByteString.Lazy        as LBS
+import           System.Directory            (renameFile)
+import           System.IO                   (withFile, Handle, IOMode (..))
+
+import qualified Store
+
+data PersistenceException = PersistenceException String
+  deriving (Show)
+
+instance Exception PersistenceException
+
+data PersistentValue = PersistentValue
+  { pvConfig  :: PersistenceConfig
+  , pvValue   :: TVar Store.Value
+  , pvIsDirty :: TVar Bool
+  , pvJournal :: Maybe Handle
+  }
+
+data PersistenceConfig = PersistenceConfig
+  { pcEnableJournaling :: Bool
+  , pcDataFile         :: FilePath
+  }
+
+-- | Get the actual value
+getValue :: PersistentValue -> STM Store.Value
+getValue = readTVar . pvValue
+
+-- | Apply a modification, and write it to the journal if enabled.
+apply :: Store.Modification -> PersistentValue -> IO ()
+apply op val = do
+  -- TODO: append to journal if enabled
+  atomically $ do
+    modifyTVar (pvValue val) (Store.applyModification op)
+    writeTVar (pvIsDirty val) True
+
+-- * IO
+
+load :: PersistenceConfig -> IO (Either String PersistentValue)
+load config = runExceptT $ do
+  value <- readData (pcDataFile config)
+  valueVar <- lift $ newTVarIO value
+  dirtyVar <- lift $ newTVarIO False
+  return PersistentValue
+    { pvConfig  = config
+    , pvValue   = valueVar
+    , pvIsDirty = dirtyVar
+    , pvJournal = Nothing
+    }
+
+-- | Read and decode the data file
+readData :: FilePath -> ExceptT String IO Store.Value
+readData filePath = ExceptT $ do
+  eitherEncodedValue <- try $ withFile filePath ReadMode SBS.hGetContents
+  case (eitherEncodedValue :: Either SomeException SBS.ByteString) of
+    Left exc -> pure $ Left $ "Failed to read the data from disk: " ++ show exc
+    Right encodedValue -> do
+      case Aeson.eitherDecodeStrict encodedValue of
+        Left msg  -> pure $ Left $ "Failed to decode the initial data: " ++ show msg
+        Right value -> pure $ Right $ value
+
+sync :: PersistentValue -> IO ()
+sync val = do
+  (dirty, value) <- atomically $ (,) <$> readTVar (pvIsDirty val)
+                                     <*> readTVar (pvValue val)
+                                     <*  writeTVar (pvIsDirty val) False
+  -- simple optimization: only write when something changed
+  when dirty $ do
+    let fileName = pcDataFile $ pvConfig val
+        tempFileName = fileName ++ ".new"
+    -- we first write to a temporary file here and then do a rename on it
+    -- because rename is atomic on Posix and a crash during writing the
+    -- temporary file will thus not corrupt the datastore
+    LBS.writeFile tempFileName (Aeson.encode value)
+    renameFile tempFileName fileName
+
+-- * Private helper functions

--- a/server/src/Persistence.hs
+++ b/server/src/Persistence.hs
@@ -90,9 +90,11 @@ sync val = do
     -- because rename is atomic on Posix and a crash during writing the
     -- temporary file will thus not corrupt the datastore
     LBS.writeFile tempFileName (Aeson.encode value)
+    renameFile tempFileName fileName
+    -- the journal is idempotent, so there is no harm if icepeak crashes between
+    -- the previous and the next action
     for_ (pvJournal val) $ \journalHandle ->
       hSetFileSize journalHandle 0
-    renameFile tempFileName fileName
 
 -- * Private helper functions
 

--- a/server/src/Persistence.hs
+++ b/server/src/Persistence.hs
@@ -35,7 +35,9 @@ import qualified Store
 data PersistentValue = PersistentValue
   { pvConfig  :: PersistenceConfig
   , pvValue   :: TVar Store.Value
+    -- ^ contains the state of the whole database
   , pvIsDirty :: TVar Bool
+    -- ^ flag indicating whether the current value of 'pvValue' has not yet been persisted to disk
   , pvJournal :: Maybe Handle
   }
 

--- a/server/src/Persistence.hs
+++ b/server/src/Persistence.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-| This module abstracts over the details of persisting the value. Journaling is
   also handled here, if enabled. -}
 module Persistence
@@ -12,18 +13,20 @@ module Persistence
 import           Control.Concurrent.STM
 import           Control.Exception
 import           Control.Monad.Except
-import qualified Data.Aeson                  as Aeson
-import qualified Data.ByteString             as SBS
-import qualified Data.ByteString.Lazy        as LBS
-import           System.Directory            (renameFile)
-import           System.IO                   (withFile, Handle, IOMode (..))
+import qualified Data.Aeson                 as Aeson
+import qualified Data.ByteString            as SBS
+import qualified Data.ByteString.Char8      as SBS8
+import qualified Data.ByteString.Lazy       as LBS
+import qualified Data.ByteString.Lazy.Char8 as LBS8
+import           Data.Either                (partitionEithers)
+import           Data.Foldable
+import           Data.Text                  (Text)
+import qualified Data.Text                  as Text
+import           Data.Traversable
+import           System.Directory           (renameFile)
+import           System.IO
 
 import qualified Store
-
-data PersistenceException = PersistenceException String
-  deriving (Show)
-
-instance Exception PersistenceException
 
 data PersistentValue = PersistentValue
   { pvConfig  :: PersistenceConfig
@@ -33,8 +36,9 @@ data PersistentValue = PersistentValue
   }
 
 data PersistenceConfig = PersistenceConfig
-  { pcEnableJournaling :: Bool
-  , pcDataFile         :: FilePath
+  { pcDataFile    :: FilePath
+  , pcJournalFile :: Maybe FilePath
+  , pcLog         :: Text -> IO ()
   }
 
 -- | Get the actual value
@@ -44,36 +48,33 @@ getValue = readTVar . pvValue
 -- | Apply a modification, and write it to the journal if enabled.
 apply :: Store.Modification -> PersistentValue -> IO ()
 apply op val = do
-  -- TODO: append to journal if enabled
+  -- append to journal if enabled
+  for_ (pvJournal val) $ \journalHandle ->
+    LBS8.hPutStrLn journalHandle (Aeson.encode op)
+  -- update value
   atomically $ do
     modifyTVar (pvValue val) (Store.applyModification op)
     writeTVar (pvIsDirty val) True
 
 -- * IO
 
+-- | Load the persisted data from disk and recover journal entries.
 load :: PersistenceConfig -> IO (Either String PersistentValue)
 load config = runExceptT $ do
   value <- readData (pcDataFile config)
   valueVar <- lift $ newTVarIO value
   dirtyVar <- lift $ newTVarIO False
-  return PersistentValue
-    { pvConfig  = config
-    , pvValue   = valueVar
-    , pvIsDirty = dirtyVar
-    , pvJournal = Nothing
-    }
+  journal <- for (pcJournalFile config) openJournal
+  let val = PersistentValue
+        { pvConfig  = config
+        , pvValue   = valueVar
+        , pvIsDirty = dirtyVar
+        , pvJournal = journal
+        }
+  replayJournal val
+  return val
 
--- | Read and decode the data file
-readData :: FilePath -> ExceptT String IO Store.Value
-readData filePath = ExceptT $ do
-  eitherEncodedValue <- try $ withFile filePath ReadMode SBS.hGetContents
-  case (eitherEncodedValue :: Either SomeException SBS.ByteString) of
-    Left exc -> pure $ Left $ "Failed to read the data from disk: " ++ show exc
-    Right encodedValue -> do
-      case Aeson.eitherDecodeStrict encodedValue of
-        Left msg  -> pure $ Left $ "Failed to decode the initial data: " ++ show msg
-        Right value -> pure $ Right $ value
-
+-- | Write the data to disk if it has changed.
 sync :: PersistentValue -> IO ()
 sync val = do
   (dirty, value) <- atomically $ (,) <$> readTVar (pvIsDirty val)
@@ -87,6 +88,73 @@ sync val = do
     -- because rename is atomic on Posix and a crash during writing the
     -- temporary file will thus not corrupt the datastore
     LBS.writeFile tempFileName (Aeson.encode value)
+    for_ (pvJournal val) $ \journalHandle ->
+      hSetFileSize journalHandle 0
     renameFile tempFileName fileName
 
 -- * Private helper functions
+
+-- | Open or create the journal file
+openJournal :: FilePath -> ExceptT String IO Handle
+openJournal journalFile = ExceptT $ do
+  eitherHandle <- try $ do
+    h <- openBinaryFile journalFile ReadWriteMode
+    hSetBuffering h LineBuffering
+    pure h
+  case eitherHandle :: Either SomeException Handle of
+    Left exc -> pure $ Left $ "Failed to open journal file: " ++ show exc
+    Right fileHandle -> pure $ Right fileHandle
+
+-- | Read the modifications from the journal file, apply them and sync again.
+-- This should be done when loading the database from disk.
+replayJournal :: PersistentValue -> ExceptT String IO ()
+replayJournal pval = for_ (pvJournal pval) $ \journalHandle -> ExceptT $ fmap formatErr $ try $ do
+  -- read modifications from the beginning
+  journalLines <- do
+    hSeek journalHandle AbsoluteSeek 0
+    readLines journalHandle
+  -- parse and apply modifications from journal
+  let (errs, ops) = partitionEithers $ map Aeson.eitherDecodeStrict journalLines
+      update initial = foldl' (flip Store.applyModification) initial ops
+
+  when (not $ null ops) $ do
+    pcLog (pvConfig pval) "Journal not empty, recovering"
+
+  when (not $ null errs) $ do
+    let msg = Text.intercalate "\n" $ "Failed to recover some journal entries:" : map Text.pack errs
+    pcLog (pvConfig pval) msg
+
+  atomically $ do
+    modifyTVar' (pvValue pval) update
+    writeTVar (pvIsDirty pval) True
+  -- syncing takes care of cleaning the journal
+  sync pval
+
+  when (not $ null ops) $ do
+    pcLog (pvConfig pval) "Journal replayed"
+
+
+  where
+    formatErr :: Either SomeException a -> Either String a
+    formatErr (Left exc) = Left $ "Failed to read journal: " ++ show exc
+    formatErr (Right x)  = Right x
+
+-- | Read and decode the data file
+readData :: FilePath -> ExceptT String IO Store.Value
+readData filePath = ExceptT $ do
+  eitherEncodedValue <- try $ withFile filePath ReadMode SBS.hGetContents
+  case (eitherEncodedValue :: Either SomeException SBS.ByteString) of
+    Left exc -> pure $ Left $ "Failed to read the data from disk: " ++ show exc
+    Right encodedValue -> do
+      case Aeson.eitherDecodeStrict encodedValue of
+        Left msg  -> pure $ Left $ "Failed to decode the initial data: " ++ show msg
+        Right value -> pure $ Right $ value
+
+-- | Read all lines of a file. Handle remains open when completed.
+readLines :: Handle -> IO [SBS.ByteString]
+readLines h = go where
+  go = do
+    eof <- hIsEOF h
+    if eof
+      then pure []
+      else (:) <$> SBS8.hGetLine h <*> go

--- a/server/src/Store.hs
+++ b/server/src/Store.hs
@@ -34,10 +34,10 @@ instance Aeson.ToJSON Modification where
   toJSON (Put path value) = Aeson.object
     [ "op" .= ("put" :: Text)
     , "path" .= path
-    , "val" .= value
+    , "value" .= value
     ]
   toJSON (Delete path) = Aeson.object
-    [ "op" .= ("del" :: Text)
+    [ "op" .= ("delete" :: Text)
     , "path" .= path
     ]
 
@@ -45,8 +45,8 @@ instance Aeson.FromJSON Modification where
   parseJSON = Aeson.withObject "Modification" $ \v -> do
     op <- v .: "op"
     case op of
-      "put" -> Put <$> v .: "path" <*> v .: "val"
-      "del" -> Delete <$> v .: "path"
+      "put" -> Put <$> v .: "path" <*> v .: "value"
+      "delete" -> Delete <$> v .: "path"
       other -> Aeson.typeMismatch "Op" other
 
 -- | Return the path that is touched by a modification.

--- a/server/src/Store.hs
+++ b/server/src/Store.hs
@@ -1,6 +1,10 @@
 module Store
 (
+  Modification (..),
   Path,
+  Value,
+  modificationPath,
+  applyModification,
   delete,
   insert,
   lookup,
@@ -17,6 +21,18 @@ import qualified Data.HashMap.Strict as HashMap
 
 type Path = [Text]
 
+-- A modification operation.
+data Modification
+  = Put Path Value
+  | Delete Path
+  deriving (Eq, Show)
+
+-- | Return the path that is touched by a modification.
+modificationPath :: Modification -> Path
+modificationPath op = case op of
+  Put path _ -> path
+  Delete path -> path
+
 lookup :: Path -> Value -> Maybe Value
 lookup path value =
   case path of
@@ -28,6 +44,11 @@ lookup path value =
 -- Look up a value, returning null if the path does not exist.
 lookupOrNull :: Path -> Value -> Value
 lookupOrNull path = fromMaybe Null . lookup path
+
+-- | Execute a modification.
+applyModification :: Modification -> Value -> Value
+applyModification (Delete path) value = Store.delete path value
+applyModification (Put path newValue) value = Store.insert path newValue value
 
 -- Overwrite a value at the given path, and create the path leading up to it if
 -- it did not exist.

--- a/server/src/Types.hs
+++ b/server/src/Types.hs
@@ -1,0 +1,2 @@
+module Types where
+

--- a/server/src/Types.hs
+++ b/server/src/Types.hs
@@ -1,2 +1,0 @@
-module Types where
-

--- a/server/tests/CoreSpec.hs
+++ b/server/tests/CoreSpec.hs
@@ -2,61 +2,7 @@
 
 module CoreSpec (spec) where
 
-import Data.Aeson (Value (..))
-import Test.Hspec (Spec, describe, it, shouldBe)
-
-import qualified Data.HashMap.Strict as HashMap
-
-import Core (Modification (..), applyModification)
+import Test.Hspec
 
 spec :: Spec
-spec = do
-  describe "Core.applyModification" $ do
-
-    it "creates an object when putting 'x' into Null" $
-      let
-        put = Put ["x"] (String "Robert")
-        before = Null
-        after = Object $ HashMap.singleton "x" (String "Robert")
-      in
-        applyModification put before `shouldBe` after
-
-    it "overwrites a key when putting 'x' into {'x': ...}" $
-      let
-        put = Put ["x"] (String "Robert")
-        before = Object $ HashMap.singleton "x" (String "Arian")
-        after = Object $ HashMap.singleton "x" (String "Robert")
-      in
-        applyModification put before `shouldBe` after
-
-    it "adds a key when putting 'x' into {'y': ...}" $
-      let
-        put = Put ["x"] (String "Robert")
-        before = Object $ HashMap.singleton "y" (String "Arian")
-        after = Object $ HashMap.fromList [("x", String "Robert"), ("y", String "Arian")]
-      in
-        applyModification put before `shouldBe` after
-
-    it "creates a nested object when putting 'x/y' into Null" $
-      let
-        put = Put ["x", "y"] (String "Stefan")
-        before = Null
-        after = Object $ HashMap.singleton "x" $ Object $ HashMap.singleton "y" "Stefan"
-      in
-        applyModification put before `shouldBe` after
-
-    it "updates a nested object when putting 'x/y' into {'x': {'y': ...}}" $
-      let
-        put = Put ["x", "y"] (String "Stefan")
-        before = Object $ HashMap.singleton "x" $ Object $ HashMap.singleton "y" "Radek"
-        after = Object $ HashMap.singleton "x" $ Object $ HashMap.singleton "y" "Stefan"
-      in
-        applyModification put before `shouldBe` after
-
-    it "adds a nested key when putting 'x/y' into {'x': {'y': ...}, 'z': ...}" $
-      let
-        put = Put ["x", "y"] (String "Stefan")
-        before = Object $ HashMap.fromList [("x", Object $ HashMap.singleton "y" "Nuno"), ("z", Null)]
-        after = Object $ HashMap.fromList [("x", Object $ HashMap.singleton "y" "Stefan"), ("z", Null)]
-      in
-        applyModification put before `shouldBe` after
+spec = return ()

--- a/server/tests/OrphanInstances.hs
+++ b/server/tests/OrphanInstances.hs
@@ -1,9 +1,11 @@
 module OrphanInstances where
 
+import Data.Aeson (Value (..))
 import Test.QuickCheck.Instances ()
 import Test.QuickCheck.Arbitrary (Arbitrary (..))
 import qualified Test.QuickCheck.Gen as Gen
 
+import Store (Modification (..))
 import AccessControl
 
 instance Arbitrary AccessMode where
@@ -14,3 +16,18 @@ instance Arbitrary AuthPath where
 
 instance Arbitrary IcepeakClaim where
   arbitrary = IcepeakClaim <$> arbitrary
+
+instance Arbitrary Modification where
+  arbitrary = Gen.oneof
+    [ Put <$> arbitrary <*> arbitrary
+    , Delete <$> arbitrary
+    ]
+
+instance Arbitrary Value where
+  arbitrary = Gen.oneof
+    [ Object <$> Gen.scale (`div` 2) arbitrary
+    , Array  <$> Gen.scale (`div` 2) arbitrary
+    , String <$> arbitrary
+    , Bool   <$> arbitrary
+    , pure Null
+    ]

--- a/server/tests/PersistenceSpec.hs
+++ b/server/tests/PersistenceSpec.hs
@@ -1,21 +1,17 @@
 {-# LANGUAGE OverloadedStrings #-}
 module PersistenceSpec (spec) where
 
---import Data.Aeson (Value (..))
+import Data.Foldable
 import Test.Hspec
 import Test.Hspec.QuickCheck (prop)
 import Test.QuickCheck.Instances ()
---import Test.QuickCheck.Arbitrary (Arbitrary (..))
 
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as LBS8
---import qualified Data.HashMap.Strict as HashMap
---import qualified Test.QuickCheck.Gen as Gen
 
 import OrphanInstances ()
 import Store (Modification (..))
-import qualified Persistence
---import qualified Store
+import qualified Store
 
 spec :: Spec
 spec = do
@@ -30,20 +26,6 @@ spec = do
       in Just op == decoded
 
   describe "Journaling" $ do
-    prop "does not crash when replaying faulty journal" $ \ops initial cutoff ->
-      let journalLines = map Aeson.encode (ops :: [Modification])
-          journal = LBS8.intercalate "\n" journalLines
-          brokenJournal = LBS8.take (LBS8.length journal - cutoff) journal
-          brokenLines = map LBS8.toStrict $ LBS8.split '\n' brokenJournal
-          (errs, restoredOps) = Persistence.parseJournalData brokenLines
-          val = Persistence.replayModifications restoredOps initial
-      in errs `seq` val `seq` True
-
-    prop "parses valid journal without errors" $ \ops ->
-      let journalLines = map (LBS8.toStrict . Aeson.encode) (ops :: [Modification])
-          (errs, restoredOps) = Persistence.parseJournalData journalLines
-      in null errs && restoredOps == ops
-
     prop "journal is idempotent" $ \ops initial ->
-      let replay = Persistence.replayModifications ops
+      let replay value = foldl' (flip Store.applyModification) value (ops :: [Modification])
       in replay initial == replay (replay initial)

--- a/server/tests/PersistenceSpec.hs
+++ b/server/tests/PersistenceSpec.hs
@@ -43,3 +43,7 @@ spec = do
       let journalLines = map (LBS8.toStrict . Aeson.encode) (ops :: [Modification])
           (errs, restoredOps) = Persistence.parseJournalData journalLines
       in null errs && restoredOps == ops
+
+    prop "journal is idempotent" $ \ops initial ->
+      let replay = Persistence.replayModifications ops
+      in replay initial == replay (replay initial)

--- a/server/tests/PersistenceSpec.hs
+++ b/server/tests/PersistenceSpec.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE OverloadedStrings #-}
+module PersistenceSpec (spec) where
+
+--import Data.Aeson (Value (..))
+import Test.Hspec
+import Test.Hspec.QuickCheck (prop)
+import Test.QuickCheck.Instances ()
+--import Test.QuickCheck.Arbitrary (Arbitrary (..))
+
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy.Char8 as LBS8
+--import qualified Data.HashMap.Strict as HashMap
+--import qualified Test.QuickCheck.Gen as Gen
+
+import OrphanInstances ()
+import Store (Modification (..))
+import qualified Persistence
+--import qualified Store
+
+spec :: Spec
+spec = do
+  describe "Store.Modification" $ do
+    prop "does not contain new lines when serialized" $ \op ->
+      let jsonStr = Aeson.encode (op :: Modification)
+      in '\n' `LBS8.notElem` jsonStr
+
+    prop "round trips serialization" $ \op ->
+      let jsonStr = Aeson.encode (op :: Modification)
+          decoded = Aeson.decode jsonStr
+      in Just op == decoded
+
+  describe "Journaling" $ do
+    prop "does not crash when replaying faulty journal" $ \ops initial cutoff ->
+      let journalLines = map Aeson.encode (ops :: [Modification])
+          journal = LBS8.intercalate "\n" journalLines
+          brokenJournal = LBS8.take (LBS8.length journal - cutoff) journal
+          brokenLines = map LBS8.toStrict $ LBS8.split '\n' brokenJournal
+          (errs, restoredOps) = Persistence.parseJournalData brokenLines
+          val = Persistence.replayModifications restoredOps initial
+      in errs `seq` val `seq` True
+
+    prop "parses valid journal without errors" $ \ops ->
+      let journalLines = map (LBS8.toStrict . Aeson.encode) (ops :: [Modification])
+          (errs, restoredOps) = Persistence.parseJournalData journalLines
+      in null errs && restoredOps == ops

--- a/server/tests/Spec.hs
+++ b/server/tests/Spec.hs
@@ -4,6 +4,7 @@ import qualified AccessControlSpec
 import qualified ApiSpec
 import qualified CoreSpec
 import qualified JwtSpec
+import qualified PersistenceSpec
 import qualified SocketSpec
 import qualified StoreSpec
 import qualified SubscriptionTreeSpec
@@ -14,6 +15,7 @@ main = hspec $ do
   ApiSpec.spec
   CoreSpec.spec
   JwtSpec.spec
+  PersistenceSpec.spec
   SocketSpec.spec
   StoreSpec.spec
   SubscriptionTreeSpec.spec

--- a/server/tests/StoreSpec.hs
+++ b/server/tests/StoreSpec.hs
@@ -6,22 +6,12 @@ import Data.Aeson (Value (..))
 import Test.Hspec (Spec, describe, it, shouldBe)
 import Test.Hspec.QuickCheck (prop)
 import Test.QuickCheck.Instances ()
-import Test.QuickCheck.Arbitrary (Arbitrary (..))
 
 import qualified Data.HashMap.Strict as HashMap
-import qualified Test.QuickCheck.Gen as Gen
 
+import OrphanInstances ()
 import Store (Modification (..))
 import qualified Store
-
-instance Arbitrary Value where
-  arbitrary = Gen.oneof
-    [ Object <$> arbitrary
-    , Array  <$> arbitrary
-    , String <$> arbitrary
-    , Bool   <$> arbitrary
-    , pure Null
-    ]
 
 spec :: Spec
 spec = do

--- a/server/tests/StoreSpec.hs
+++ b/server/tests/StoreSpec.hs
@@ -126,3 +126,7 @@ spec = do
         after = Object $ HashMap.fromList [("x", Object $ HashMap.singleton "y" "Stefan"), ("z", Null)]
       in
         Store.applyModification put before `shouldBe` after
+
+    prop "is idempotent" $ \op value ->
+      let apply = Store.applyModification op
+      in apply value == apply (apply value)

--- a/server/tests/StoreSpec.hs
+++ b/server/tests/StoreSpec.hs
@@ -11,6 +11,7 @@ import Test.QuickCheck.Arbitrary (Arbitrary (..))
 import qualified Data.HashMap.Strict as HashMap
 import qualified Test.QuickCheck.Gen as Gen
 
+import Store (Modification (..))
 import qualified Store
 
 instance Arbitrary Value where
@@ -85,3 +86,53 @@ spec = do
         if path == []
           then lkupDelIns before `shouldBe` (Just Null)
           else lkupDelIns before `shouldBe` Nothing
+
+  describe "Store.applyModification" $ do
+
+    it "creates an object when putting 'x' into Null" $
+      let
+        put = Put ["x"] (String "Robert")
+        before = Null
+        after = Object $ HashMap.singleton "x" (String "Robert")
+      in
+        Store.applyModification put before `shouldBe` after
+
+    it "overwrites a key when putting 'x' into {'x': ...}" $
+      let
+        put = Put ["x"] (String "Robert")
+        before = Object $ HashMap.singleton "x" (String "Arian")
+        after = Object $ HashMap.singleton "x" (String "Robert")
+      in
+        Store.applyModification put before `shouldBe` after
+
+    it "adds a key when putting 'x' into {'y': ...}" $
+      let
+        put = Put ["x"] (String "Robert")
+        before = Object $ HashMap.singleton "y" (String "Arian")
+        after = Object $ HashMap.fromList [("x", String "Robert"), ("y", String "Arian")]
+      in
+        Store.applyModification put before `shouldBe` after
+
+    it "creates a nested object when putting 'x/y' into Null" $
+      let
+        put = Put ["x", "y"] (String "Stefan")
+        before = Null
+        after = Object $ HashMap.singleton "x" $ Object $ HashMap.singleton "y" "Stefan"
+      in
+        Store.applyModification put before `shouldBe` after
+
+    it "updates a nested object when putting 'x/y' into {'x': {'y': ...}}" $
+      let
+        put = Put ["x", "y"] (String "Stefan")
+        before = Object $ HashMap.singleton "x" $ Object $ HashMap.singleton "y" "Radek"
+        after = Object $ HashMap.singleton "x" $ Object $ HashMap.singleton "y" "Stefan"
+      in
+        Store.applyModification put before `shouldBe` after
+
+    it "adds a nested key when putting 'x/y' into {'x': {'y': ...}, 'z': ...}" $
+      let
+        put = Put ["x", "y"] (String "Stefan")
+        before = Object $ HashMap.fromList [("x", Object $ HashMap.singleton "y" "Nuno"), ("z", Null)]
+        after = Object $ HashMap.fromList [("x", Object $ HashMap.singleton "y" "Stefan"), ("z", Null)]
+      in
+        Store.applyModification put before `shouldBe` after


### PR DESCRIPTION
If enabled (only applicable in combination with periodic syncing), every modification is written to a journal before being applied to the internal JSON value. When writing the latest version to disk, the journal is cleared.
If the journal is not empty when starting up, Icepeak recovers the database by replaying all modifications in the journal to the stored value. This allows to recover most or all of the data even in the case of a hard crash (i.e. power outage).

This addresses the second part of #19.