### PR TITLE
Fix logging

### DIFF
--- a/server/src/MetricsServer.hs
+++ b/server/src/MetricsServer.hs
@@ -1,18 +1,24 @@
+{-# LANGUAGE OverloadedStrings #-}
 module MetricsServer where
 
 import           Data.Function                     ((&))
+import           Data.Monoid                       ((<>))
+import qualified Data.Text                         as Text
 import qualified Network.Wai.Handler.Warp          as Warp
 import qualified Network.Wai.Middleware.Prometheus as PrometheusWai
-import           Text.Printf                       (printf)
 
 import           Config                            (MetricsConfig (..))
+import           Logger                            (Logger, postLog)
 
 metricsServerConfig :: MetricsConfig -> Warp.Settings
 metricsServerConfig config = Warp.defaultSettings
   & Warp.setHost (metricsConfigHost config)
   & Warp.setPort (metricsConfigPort config)
 
-runMetricsServer :: MetricsConfig -> IO ()
-runMetricsServer metricsConfig = do
-  printf "Metrics provided on %s:%d.\n" (show $ metricsConfigHost metricsConfig) (metricsConfigPort metricsConfig)
+runMetricsServer :: Logger -> MetricsConfig -> IO ()
+runMetricsServer logger metricsConfig = do
+  Logger.postLog logger $ "Metrics provided on "
+    <> (Text.pack $ show $ metricsConfigHost metricsConfig)
+    <> ":"
+    <> (Text.pack $ show $ metricsConfigPort metricsConfig)
   Warp.runSettings (metricsServerConfig metricsConfig) PrometheusWai.metricsApp

--- a/server/src/Server.hs
+++ b/server/src/Server.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 module Server
 (
   runServer,
@@ -11,10 +12,12 @@ import Network.WebSockets (ServerApp)
 import qualified Network.Wai.Handler.Warp as Warp
 import qualified Network.WebSockets as WebSockets
 
-runServer :: ServerApp -> Application -> IO ()
-runServer wsApp httpApp =
+import Logger (Logger, postLog)
+
+runServer :: Logger -> ServerApp -> Application -> IO ()
+runServer logger wsApp httpApp =
   let
     wsConnectionOpts = WebSockets.defaultConnectionOptions
   in do
-    putStrLn "Listening on port 3000."
+    postLog logger "Listening on port 3000."
     Warp.run 3000 $ websocketsOr wsConnectionOpts wsApp httpApp


### PR DESCRIPTION
Every log message is now going through the `Logger` module, fixing that messages
were sometimes printed somewhat interleaved. Moreover `stdout` is set to line
buffering to make sure every log entry is written as soon as it is ready.