### PR TITLE
Make icepeak port configurable

### DIFF
--- a/server/app/Icepeak/Main.hs
+++ b/server/app/Icepeak/Main.hs
@@ -81,7 +81,7 @@ runCore core = do
   pops <- Async.async $ Core.runCommandLoop core
   sync <- Async.async $ Core.runSyncTimer core
   upds <- Async.async $ WebsocketServer.processUpdates core
-  serv <- Async.async $ Server.runServer logger wsServer httpServer
+  serv <- Async.async $ Server.runServer logger wsServer httpServer (configPort config)
   metrics <- Async.async
     $ forM_ (configMetricsEndpoint config) (MetricsServer.runMetricsServer logger)
   installHandlers core serv

--- a/server/integration-tests/using-different-ports.sh
+++ b/server/integration-tests/using-different-ports.sh
@@ -1,0 +1,110 @@
+#/bin/bash
+
+if [ ! -f "stack.yaml" ]; then
+    echo "Run test in server package directory"
+    exit 1
+fi
+
+########## Preparations
+stack build
+DATA_FILE=`mktemp`
+echo '{"foo": {"a": 123}}' > "$DATA_FILE"
+lsof -i :3000 > /dev/null
+if [ $? -eq 0 ]; then
+    echo "ERROR: Another program is already using port 3000"
+    exit 1
+fi
+lsof -i :3001 > /dev/null
+if [ $? -eq 0 ]; then
+    echo "ERROR: Another program is already using port 3001"
+    exit 1
+fi
+RESULT_CODE=0
+
+########## Running tests
+echo ""; echo "## Should default on port 3000"
+stack exec -- icepeak --data-file="$DATA_FILE" > /dev/null &
+ICEPEAK_PID=$!
+sleep 1
+RESULT=`curl -sS localhost:3000/foo/a`
+if [ "$RESULT" -eq 123 ]; then
+    echo "PASSED"
+else
+    echo "FAILED"
+    (( RESULT_CODE=RESULT_CODE+1 ))
+fi
+kill -9 $ICEPEAK_PID; wait $ICEPEAK_PID 2> /dev/null
+
+echo ""; echo "## Should use --port if given"
+stack exec -- icepeak --data-file="$DATA_FILE" --port 3001 > /dev/null &
+ICEPEAK_PID=$!
+sleep 1
+RESULT=`curl -sS localhost:3001/foo/a`
+if [ "$RESULT" -eq "123" ]; then
+    echo "PASSED"
+else
+    echo "FAILED"
+    (( RESULT_CODE=RESULT_CODE+1 ))
+fi
+kill -9 $ICEPEAK_PID; wait $ICEPEAK_PID 2> /dev/null
+
+echo ""; echo "## Should use ICEPEAK_PORT if given"
+ICEPEAK_PORT=3001 stack exec -- icepeak --data-file="$DATA_FILE" > /dev/null &
+ICEPEAK_PID=$!
+sleep 1
+RESULT=`curl -sS localhost:3001/foo/a`
+if [ "$RESULT" -eq "123" ]; then
+    echo "PASSED"
+else
+    echo "FAILED"
+    (( RESULT_CODE=RESULT_CODE+1 ))
+fi
+kill -9 $ICEPEAK_PID; wait $ICEPEAK_PID 2> /dev/null
+
+echo ""; echo "## Should prefer --port over ICEPEAK_PORT"
+ICEPEAK_PORT=9999 stack exec -- icepeak --data-file="$DATA_FILE" --port=3001 > /dev/null &
+ICEPEAK_PID=$!
+sleep 1
+RESULT=`curl -sS localhost:3001/foo/a`
+if [ "$RESULT" -eq "123" ]; then
+    echo "PASSED"
+else
+    echo "FAILED"
+    (( RESULT_CODE=RESULT_CODE+1 ))
+fi
+kill -9 $ICEPEAK_PID; wait $ICEPEAK_PID 2> /dev/null
+
+echo ""; echo "## Should ignore ICEPEAK_PORT if it is not a number"
+ICEPEAK_PORT=notanumber stack exec -- icepeak --data-file="$DATA_FILE" > /dev/null &
+ICEPEAK_PID=$!
+sleep 1
+RESULT=`curl -sS localhost:3000/foo/a`
+if [ "$RESULT" -eq "123" ]; then
+    echo "PASSED"
+else
+    echo "FAILED"
+    (( RESULT_CODE=RESULT_CODE+1 ))
+fi
+kill -9 $ICEPEAK_PID; wait $ICEPEAK_PID 2> /dev/null
+
+echo ""; echo "## Should fail if --port is not a number"
+stack exec -- icepeak --data-file="$DATA_FILE" --port=notanumber > /dev/null 2> /dev/null
+if [ "$?" -eq "0" ]; then
+    echo "FAILED"
+    (( RESULT_CODE=RESULT_CODE+1 ))
+else
+    echo "PASSED"
+fi
+
+########## Cleanup
+rm "$DATA_FILE"
+
+########## Evaluation
+echo ""
+if [ "$RESULT_CODE" -eq "0" ]; then
+    echo "ALL PASSED"
+    exit 0
+else
+    echo "$RESULT_CODE FAILURES"
+    exit $RESULT_CODE
+fi

--- a/server/src/Config.hs
+++ b/server/src/Config.hs
@@ -20,6 +20,7 @@ import qualified Web.JWT as JWT
 -- command-line arguments
 data Config = Config
   { configDataFile :: FilePath
+  , configPort :: Int
     -- | Enables the use of JWT for authorization in JWT.
   , configEnableJwtAuth :: Bool
     -- | The secret used for verifying the JWT signatures. If no secret is
@@ -51,6 +52,10 @@ configParser environment = Config
                  metavar "DATA_FILE" <>
                  value "icepeak.json" <>
                  help "File where data is persisted to. Default: icepeak.json")
+  <*> option auto (long "port" <>
+                   metavar "PORT" <>
+                   maybe (value 3000) value (readFromEnvironment "ICEPEAK_PORT") <>
+                   help "Port to listen on, defaults to the value of the ICEPEAK_PORT environment variable if present, or 3000 if not")
   <*> switch (long "enable-jwt-auth" <>
                 help "Enable authorization using JSON Web Tokens.")
   <*> optional (secretOption (
@@ -79,6 +84,10 @@ configParser environment = Config
              help "Enable journaling. This only has an effect when periodic syncing is enabled.")
   where
     environ var = foldMap value (lookup var environment)
+
+    readFromEnvironment :: Read a => String -> Maybe a
+    readFromEnvironment var = lookup var environment >>= Read.readMaybe
+
     secretOption m = JWT.secret . Text.pack <$> strOption m
 
 configInfo :: EnvironmentConfig -> ParserInfo Config

--- a/server/src/Server.hs
+++ b/server/src/Server.hs
@@ -5,6 +5,9 @@ module Server
 )
 where
 
+import Data.Semigroup ((<>))
+import Data.Text (pack)
+
 import Network.Wai (Application)
 import Network.Wai.Handler.WebSockets (websocketsOr)
 import Network.WebSockets (ServerApp)
@@ -14,10 +17,10 @@ import qualified Network.WebSockets as WebSockets
 
 import Logger (Logger, postLog)
 
-runServer :: Logger -> ServerApp -> Application -> IO ()
-runServer logger wsApp httpApp =
+runServer :: Logger -> ServerApp -> Application -> Int -> IO ()
+runServer logger wsApp httpApp port =
   let
     wsConnectionOpts = WebSockets.defaultConnectionOptions
   in do
-    postLog logger "Listening on port 3000."
-    Warp.run 3000 $ websocketsOr wsConnectionOpts wsApp httpApp
+    postLog logger $ pack $ "Listening on port " <> show port <> "."
+    Warp.run port $ websocketsOr wsConnectionOpts wsApp httpApp


### PR DESCRIPTION
Fixes #12. Port is configurable through --port and $ICEPEAK_PORT.

Added a test for it:

```
icepeak/server$ integration-tests/using-different-ports.sh 

## Should default on port 3000
PASSED

## Should use --port if given
PASSED

## Should use ICEPEAK_PORT if given
PASSED

## Should prefer --port over ICEPEAK_PORT
PASSED

## Should ignore ICEPEAK_PORT if it is not a number
PASSED

## Should fail if --port is not a number
PASSED

ALL PASSED
```