### PR TITLE
Create an empty database if there is none yet

### DIFF
--- a/server/src/Persistence.hs
+++ b/server/src/Persistence.hs
@@ -176,7 +176,7 @@ recoverJournal pval = for_ (pvJournal pval) $ \journalHandle -> ExceptT $ fmap f
 -- | Read and decode the data file from disk
 readData :: FilePath -> Logger -> ExceptT String IO Store.Value
 readData filePath logger = ExceptT $ do
-  eitherEncodedValue <- tryIOError $ withFile filePath ReadMode SBS.hGetContents
+  eitherEncodedValue <- tryIOError $ SBS.readFile filePath
   case eitherEncodedValue of
     Left e | isDoesNotExistError e -> do
         -- If there is no icepeak.json file yet, we create an empty one instead.


### PR DESCRIPTION
If we cannot find a database at the configured file path we used to
crash with a not terribly good error message.

This PR instead logs a warning and then creates an empty database
(an empty JSON object: {}). Note, that the object will only be
persisted when some changes are written to disk.