### PR TITLE
Upgrade to stack lts-12.6 (from lts-11.20)

### DIFF
--- a/client-haskell/stack.yaml
+++ b/client-haskell/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-10.8
+resolver: lts-12.6

--- a/server/src/Metrics.hs
+++ b/server/src/Metrics.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Metrics where
 
-import Control.Monad (void)
 import Data.Text (Text, pack)
 import Data.Text.Encoding (decodeUtf8With)
 import Data.Text.Encoding.Error (lenientDecode)
@@ -50,20 +49,20 @@ createAndRegisterIcepeakMetrics = IcepeakMetrics
 notifyRequest :: Http.Method -> Http.Status -> IcepeakMetrics -> IO ()
 notifyRequest method status = countHttpRequest method status . icepeakMetricsRequestCounter
 
--- setDataSize :: Real a => a -> IcepeakMetrics -> IO ()
--- setDataSize val = setGauge (realToFrac val) . icepeakMetricsDataSize
---
--- setJournalSize :: Real a => a -> IcepeakMetrics -> IO ()
--- setJournalSize val = setGauge (realToFrac val) . icepeakMetricsJournalSize
---
--- incrementDataWritten :: Real a => a -> IcepeakMetrics -> IO ()
--- incrementDataWritten val = void . addCounter (realToFrac val) . icepeakMetricsDataWritten
---
--- incrementJournalWritten :: Real a => a -> IcepeakMetrics -> IO ()
--- incrementJournalWritten val = void . addCounter (realToFrac val) . icepeakMetricsJournalWritten
+setDataSize :: (MonadMonitor m, Real a) => a -> IcepeakMetrics -> m ()
+setDataSize val metrics = setGauge (icepeakMetricsDataSize metrics) (realToFrac val)
 
-incrementSubscribers :: IcepeakMetrics -> IO ()
+setJournalSize :: (MonadMonitor m, Real a) => a -> IcepeakMetrics -> m ()
+setJournalSize val metrics = setGauge (icepeakMetricsJournalSize metrics) (realToFrac val)
+
+incrementDataWritten :: (MonadMonitor m, Real a) => a -> IcepeakMetrics -> m Bool
+incrementDataWritten val metrics = addCounter (icepeakMetricsDataWritten metrics) (realToFrac val)
+
+incrementJournalWritten :: (MonadMonitor m, Real a) => a -> IcepeakMetrics -> m Bool
+incrementJournalWritten val metrics = addCounter (icepeakMetricsJournalWritten metrics) (realToFrac val)
+
+incrementSubscribers :: MonadMonitor m => IcepeakMetrics -> m ()
 incrementSubscribers = incGauge . icepeakMetricsSubscriberCount
 
-decrementSubscribers :: IcepeakMetrics -> IO ()
+decrementSubscribers :: MonadMonitor m => IcepeakMetrics -> m ()
 decrementSubscribers = decGauge . icepeakMetricsSubscriberCount

--- a/server/src/Metrics.hs
+++ b/server/src/Metrics.hs
@@ -1,37 +1,48 @@
+{-# LANGUAGE OverloadedStrings #-}
 module Metrics where
 
-import           Control.Monad         (void)
-import qualified Data.ByteString.Char8 as BS8
-import qualified Network.HTTP.Types    as Http
-import           Prometheus
+import Control.Monad (void)
+import Data.Text (Text, pack)
+import Data.Text.Encoding (decodeUtf8With)
+import Data.Text.Encoding.Error (lenientDecode)
 
-type HttpMethodLabel = String
-type HttpStatusLabel = String
+import qualified Network.HTTP.Types as Http
 
-type HttpRequestCounter = Vector (HttpMethodLabel, HttpStatusLabel) Counter
+import Prometheus
 
-countHttpRequest :: Http.Method -> Http.Status -> Metric HttpRequestCounter -> IO ()
-countHttpRequest method status = withLabel (BS8.unpack method, show $ Http.statusCode status) incCounter
+type HttpMethodLabel = Text
+type HttpStatusCode = Text
+
+-- We want to store for each (HTTP method, HTTP status code) pair how many times it has been called
+type HttpRequestCounter = Vector (HttpMethodLabel, HttpStatusCode) Counter
+
+countHttpRequest :: MonadMonitor m => Http.Method -> Http.Status -> HttpRequestCounter -> m ()
+countHttpRequest method status httpRequestCounter = withLabel httpRequestCounter label incCounter
+  where
+    label = (textMethod, textStatusCode)
+    textMethod = decodeUtf8With lenientDecode method
+    textStatusCode = pack $ show $ Http.statusCode status
+
 
 data IcepeakMetrics = IcepeakMetrics
-  { icepeakMetricsRequestCounter  :: Metric HttpRequestCounter
-  , icepeakMetricsDataSize        :: Metric Gauge
-  , icepeakMetricsJournalSize     :: Metric Gauge
-  , icepeakMetricsDataWritten     :: Metric Counter
-  , icepeakMetricsJournalWritten  :: Metric Counter
-  , icepeakMetricsSubscriberCount :: Metric Gauge
+  { icepeakMetricsRequestCounter  :: HttpRequestCounter
+  , icepeakMetricsDataSize        :: Gauge
+  , icepeakMetricsJournalSize     :: Gauge
+  , icepeakMetricsDataWritten     :: Counter
+  , icepeakMetricsJournalWritten  :: Counter
+  , icepeakMetricsSubscriberCount :: Gauge
   }
 
 createAndRegisterIcepeakMetrics :: IO IcepeakMetrics
 createAndRegisterIcepeakMetrics = IcepeakMetrics
-  <$> registerIO (vector ("method", "status") requestCounter)
-  <*> registerIO (gauge (Info "icepeak_data_size" "Size of data file in bytes."))
-  <*> registerIO (gauge (Info "icepeak_journal_size_bytes"
-                              "Size of journal file in bytes."))
-  <*> registerIO (counter (Info "icepeak_data_written" "Total number of bytes written so far."))
-  <*> registerIO (counter (Info "icepeak_journal_written_bytes_total"
-                                "Total number of bytes written to the journal so far."))
-  <*> registerIO (gauge (Info "icepeak_subscriber_count" "Number of websocket subscriber connections."))
+  <$> register (vector ("method", "status") requestCounter)
+  <*> register (gauge (Info "icepeak_data_size" "Size of data file in bytes."))
+  <*> register (gauge (Info "icepeak_journal_size_bytes"
+                            "Size of journal file in bytes."))
+  <*> register (counter (Info "icepeak_data_written" "Total number of bytes written so far."))
+  <*> register (counter (Info "icepeak_journal_written_bytes_total"
+                              "Total number of bytes written to the journal so far."))
+  <*> register (gauge (Info "icepeak_subscriber_count" "Number of websocket subscriber connections."))
   where
     requestCounter = counter (Info "icepeak_http_requests"
                                    "Total number of HTTP requests since starting Icepeak.")
@@ -39,17 +50,17 @@ createAndRegisterIcepeakMetrics = IcepeakMetrics
 notifyRequest :: Http.Method -> Http.Status -> IcepeakMetrics -> IO ()
 notifyRequest method status = countHttpRequest method status . icepeakMetricsRequestCounter
 
-setDataSize :: Real a => a -> IcepeakMetrics -> IO ()
-setDataSize val = setGauge (realToFrac val) . icepeakMetricsDataSize
-
-setJournalSize :: Real a => a -> IcepeakMetrics -> IO ()
-setJournalSize val = setGauge (realToFrac val) . icepeakMetricsJournalSize
-
-incrementDataWritten :: Real a => a -> IcepeakMetrics -> IO ()
-incrementDataWritten val = void . addCounter (realToFrac val) . icepeakMetricsDataWritten
-
-incrementJournalWritten :: Real a => a -> IcepeakMetrics -> IO ()
-incrementJournalWritten val = void . addCounter (realToFrac val) . icepeakMetricsJournalWritten
+-- setDataSize :: Real a => a -> IcepeakMetrics -> IO ()
+-- setDataSize val = setGauge (realToFrac val) . icepeakMetricsDataSize
+--
+-- setJournalSize :: Real a => a -> IcepeakMetrics -> IO ()
+-- setJournalSize val = setGauge (realToFrac val) . icepeakMetricsJournalSize
+--
+-- incrementDataWritten :: Real a => a -> IcepeakMetrics -> IO ()
+-- incrementDataWritten val = void . addCounter (realToFrac val) . icepeakMetricsDataWritten
+--
+-- incrementJournalWritten :: Real a => a -> IcepeakMetrics -> IO ()
+-- incrementJournalWritten val = void . addCounter (realToFrac val) . icepeakMetricsJournalWritten
 
 incrementSubscribers :: IcepeakMetrics -> IO ()
 incrementSubscribers = incGauge . icepeakMetricsSubscriberCount

--- a/server/src/Persistence.hs
+++ b/server/src/Persistence.hs
@@ -20,7 +20,6 @@ import qualified Data.ByteString.Char8      as SBS8
 import qualified Data.ByteString.Lazy       as LBS
 import qualified Data.ByteString.Lazy.Char8 as LBS8
 import           Data.Foldable
-import           Data.Monoid
 import           Data.Text                  (Text)
 import qualified Data.Text                  as Text
 import           Data.Traversable
@@ -61,7 +60,7 @@ apply op val = do
     LBS8.hPutStrLn journalHandle entry
     for_ (pcMetrics . pvConfig $ val) $ \metrics -> do
       journalPos <- hTell journalHandle
-      Metrics.incrementJournalWritten (LBS8.length entry) metrics
+      _ <- Metrics.incrementJournalWritten (LBS8.length entry) metrics
       Metrics.setJournalSize journalPos metrics
   -- update value
   atomically $ do

--- a/server/stack.yaml
+++ b/server/stack.yaml
@@ -1,9 +1,6 @@
 resolver: lts-12.5
 
 extra-deps:
-  - github: fimad/prometheus-haskell
-    commit: e44ab37a5d4e4a570e24cb1ca29d2753a27090c5
-    subdirs:
-     - prometheus-client
-     - prometheus-metrics-ghc
-     - wai-middleware-prometheus
+  - prometheus-client-1.0.0
+  - prometheus-metrics-ghc-1.0.0
+  - wai-middleware-prometheus-1.0.0

--- a/server/stack.yaml
+++ b/server/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-12.5
+resolver: lts-12.6
 
 extra-deps:
   - prometheus-client-1.0.0

--- a/server/stack.yaml
+++ b/server/stack.yaml
@@ -1,1 +1,9 @@
-resolver: lts-11.20
+resolver: lts-12.5
+
+extra-deps:
+  - github: fimad/prometheus-haskell
+    commit: e44ab37a5d4e4a570e24cb1ca29d2753a27090c5
+    subdirs:
+     - prometheus-client
+     - prometheus-metrics-ghc
+     - wai-middleware-prometheus


### PR DESCRIPTION
This also upgrades GHC from version 8.2 to 8.4.

There were some breaking changes in the `prometheus-client` package.
They changed their API in various places. The changes are described in their changelog here:

https://github.com/fimad/prometheus-haskell/blob/master/prometheus-client/CHANGELOG.md

I adjusted our Metrics.hs module to work with the new API.
For details, see the commit messages.