### PR TITLE
Pair HTTP manager with client details in one type

### DIFF
--- a/server/integration-tests/auth_stress_test.hs
+++ b/server/integration-tests/auth_stress_test.hs
@@ -12,7 +12,7 @@ import Prelude hiding (fail)
 import Data.Foldable (traverse_)
 import Data.Text (Text)
 import Data.Text.Arbitrary ()
-import Icepeak.Client (Client (..), setAtLeaf)
+import Icepeak.Client (Client (..), Config (..), setAtLeaf)
 import System.Environment (getArgs)
 import System.Exit (exitFailure)
 import System.IO (hPutStrLn, stderr)
@@ -34,12 +34,12 @@ main = do
 main' :: Int -> IO ()
 main' count = do
   httpManager <- HTTP.newManager HTTP.defaultManagerSettings
-  let client = Client "localhost" 3000 (Just testToken)
+  let client = Client httpManager (Config "localhost" 3000 (Just testToken))
   let putRandomPayload prefix i = do
         putStr $ "Test #" ++ show i ++ " ... "
         path :: [Text] <- Gen.generate arbitrary
         leaf :: Text <- Gen.generate arbitrary
-        status <- setAtLeaf httpManager client (prefix ++ path) leaf
+        status <- setAtLeaf client (prefix ++ path) leaf
         print status
   traverse_ (putRandomPayload ["bar", "baz"]) [1..count]
   traverse_ (putRandomPayload ["foo"]) [count+1..2*count]

--- a/server/integration-tests/stress_test.hs
+++ b/server/integration-tests/stress_test.hs
@@ -9,7 +9,7 @@ import Prelude hiding (fail)
 import Data.Foldable (traverse_)
 import Data.Text (Text)
 import Data.Text.Arbitrary ()
-import Icepeak.Client (Client (..), setAtLeaf)
+import Icepeak.Client (Client (..), Config (..), setAtLeaf)
 import System.Environment (getArgs)
 import System.Exit (exitFailure)
 import System.IO (hPutStrLn, stderr)
@@ -30,11 +30,11 @@ main = do
 main' :: Int -> IO ()
 main' count = do
   httpManager <- HTTP.newManager HTTP.defaultManagerSettings
-  let client = Client "localhost" 3000 Nothing
+  let client = Client httpManager (Config "localhost" 3000 Nothing)
   let putRandomPayload i = do
         putStr $ "Test #" ++ show i ++ " ... "
         path :: [Text] <- Gen.generate arbitrary
         leaf :: Text <- Gen.generate arbitrary
-        status <- setAtLeaf httpManager client path leaf
+        status <- setAtLeaf client path leaf
         print status
   traverse_ putRandomPayload [1..count]


### PR DESCRIPTION
In most use cases, you want to propagate these two together anyway. It is still
possible not to, if you want.

This is a breaking change, but we use commit-pinned versions so it's not an issue for us. People who use master as their reference will have to change their code.
