### PR TITLE
Upgrade Stack from LTS 12.6 to LTS 14.0

### DIFF
--- a/client-haskell/stack.yaml
+++ b/client-haskell/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-12.6
+resolver: lts-14.0

--- a/server/app/IcepeakTokenGen/Main.hs
+++ b/server/app/IcepeakTokenGen/Main.hs
@@ -26,11 +26,12 @@ main = do
   config <- execParser (configInfo env)
   now <- Clock.getPOSIXTime
 
-  let joseHeader = JWT.JOSEHeader {
-    JWT.typ = Just "JWT",
-    JWT.cty = Nothing,
-    JWT.alg = Just JWT.HS256,
-    JWT.kid = Nothing}
+  let joseHeader = JWT.JOSEHeader
+        { JWT.typ = Just "JWT"
+        , JWT.cty = Nothing
+        , JWT.alg = Just JWT.HS256
+        , JWT.kid = Nothing
+        }
 
   let access = IcepeakClaim (configWhitelist config)
       claims = addIcepeakClaim access $ JWT.JWTClaimsSet

--- a/server/app/IcepeakTokenGen/Main.hs
+++ b/server/app/IcepeakTokenGen/Main.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Main where
 
-import qualified Data.Map.Strict as Map
 import           Data.Semigroup      ((<>))
 import qualified Data.Text           as Text
 import qualified Data.Text.IO        as Text
@@ -14,7 +13,7 @@ import           AccessControl
 import           JwtAuth
 
 data Config = Config
-  { configJwtSecret      :: Maybe JWT.Secret
+  { configJwtSecret      :: Maybe JWT.Signer
   , configExpiresSeconds :: Maybe Integer
   , configWhitelist      :: [AuthPath]
   }
@@ -27,6 +26,12 @@ main = do
   config <- execParser (configInfo env)
   now <- Clock.getPOSIXTime
 
+  let joseHeader = JWT.JOSEHeader {
+    JWT.typ = Just "JWT",
+    JWT.cty = Nothing,
+    JWT.alg = Just JWT.HS256,
+    JWT.kid = Nothing}
+
   let access = IcepeakClaim (configWhitelist config)
       claims = addIcepeakClaim access $ JWT.JWTClaimsSet
              { JWT.iss = Nothing
@@ -36,11 +41,11 @@ main = do
              , JWT.nbf = Nothing
              , JWT.iat = Nothing
              , JWT.jti = Nothing
-             , JWT.unregisteredClaims = Map.empty
+             , JWT.unregisteredClaims = mempty
              }
       token = case configJwtSecret config of
-                Nothing -> JWT.encodeUnsigned claims
-                Just key -> JWT.encodeSigned JWT.HS256 key claims
+                Nothing -> JWT.encodeUnsigned claims joseHeader
+                Just key -> JWT.encodeSigned key joseHeader claims
   Text.putStrLn token
 
 configParser :: EnvironmentConfig -> Parser Config
@@ -64,7 +69,7 @@ configParser environment = Config
              ))
   where
     environ var = foldMap value (lookup var environment)
-    secretOption m = JWT.secret . Text.pack <$> strOption m
+    secretOption m = JWT.hmacSecret . Text.pack <$> strOption m
 
 configInfo :: EnvironmentConfig -> ParserInfo Config
 configInfo environment = info parser description

--- a/server/integration-tests/generate_test_token.hs
+++ b/server/integration-tests/generate_test_token.hs
@@ -13,7 +13,14 @@ import qualified Web.JWT as JWT
 import qualified Data.Text.IO as Text
 
 main :: IO ()
-main = Text.putStrLn $ JWT.encodeSigned JWT.HS256 testSecret testClaims
+main = Text.putStrLn $ JWT.encodeSigned testSecret joseHeader testClaims
+
+joseHeader = JWT.JOSEHeader {
+  JWT.typ = Just "JWT",
+  JWT.cty = Nothing,
+  JWT.alg = Just JWT.HS256,
+  JWT.kid = Nothing
+}
 
 testAccess :: IcepeakClaim
 testAccess = IcepeakClaim
@@ -30,8 +37,8 @@ testClaims = addIcepeakClaim testAccess $ JWT.JWTClaimsSet
   , JWT.nbf = Nothing
   , JWT.iat = Nothing
   , JWT.jti = Nothing
-  , JWT.unregisteredClaims = Map.empty
+  , JWT.unregisteredClaims = mempty
   }
 
-testSecret :: JWT.Secret
-testSecret = JWT.binarySecret "foo"
+testSecret :: JWT.Signer
+testSecret = JWT.HMACSecret "foo"

--- a/server/integration-tests/generate_test_token.hs
+++ b/server/integration-tests/generate_test_token.hs
@@ -15,12 +15,12 @@ import qualified Data.Text.IO as Text
 main :: IO ()
 main = Text.putStrLn $ JWT.encodeSigned testSecret joseHeader testClaims
 
-joseHeader = JWT.JOSEHeader {
-  JWT.typ = Just "JWT",
-  JWT.cty = Nothing,
-  JWT.alg = Just JWT.HS256,
-  JWT.kid = Nothing
-}
+joseHeader = JWT.JOSEHeader
+  { JWT.typ = Just "JWT"
+  , JWT.cty = Nothing
+  , JWT.alg = Just JWT.HS256
+  , JWT.kid = Nothing
+  }
 
 testAccess :: IcepeakClaim
 testAccess = IcepeakClaim

--- a/server/integration-tests/stress_test.hs
+++ b/server/integration-tests/stress_test.hs
@@ -22,6 +22,7 @@ import qualified Test.QuickCheck.Gen as Gen
 main :: IO ()
 main = do
   args <- getArgs
+  print args
   case args of
     [count] -> either fail main' (readEither count)
     _ -> fail "usage: stress_test.hs <count>"

--- a/server/src/Config.hs
+++ b/server/src/Config.hs
@@ -26,7 +26,7 @@ data Config = Config
     -- | The secret used for verifying the JWT signatures. If no secret is
     -- specified even though JWT authorization is enabled, tokens will still be
     -- used, but not be verified.
-  , configJwtSecret :: Maybe JWT.Secret
+  , configJwtSecret :: Maybe JWT.Signer
   , configMetricsEndpoint :: Maybe MetricsConfig
   , configQueueCapacity :: Word
   , configSyncIntervalMicroSeconds :: Maybe Int
@@ -88,7 +88,7 @@ configParser environment = Config
     readFromEnvironment :: Read a => String -> Maybe a
     readFromEnvironment var = lookup var environment >>= Read.readMaybe
 
-    secretOption m = JWT.secret . Text.pack <$> strOption m
+    secretOption m = JWT.hmacSecret . Text.pack <$> strOption m
 
 configInfo :: EnvironmentConfig -> ParserInfo Config
 configInfo environment = info parser description

--- a/server/src/JwtMiddleware.hs
+++ b/server/src/JwtMiddleware.hs
@@ -39,7 +39,7 @@ data AuthResult
 -- | Check whether accessing the given path with the given mode is authorized by
 -- the token supplied in the request headers or query string (which may not be
 -- present, then failing the check).
-isRequestAuthorized :: Http.RequestHeaders -> Http.Query -> POSIXTime -> Maybe JWT.Secret -> Path -> AccessMode -> AuthResult
+isRequestAuthorized :: Http.RequestHeaders -> Http.Query -> POSIXTime -> Maybe JWT.Signer -> Path -> AccessMode -> AuthResult
 isRequestAuthorized headers query now maybeSecret path mode =
   case getRequestClaim headers query now maybeSecret of
     Left err -> AuthRejected (TokenError err)
@@ -49,7 +49,7 @@ isRequestAuthorized headers query now maybeSecret path mode =
                   -> AuthRejected OperationNotAllowed
 
 -- | Extract the JWT claim from the request.
-getRequestClaim :: Http.RequestHeaders -> Http.Query -> POSIXTime -> Maybe JWT.Secret -> Either TokenError IcepeakClaim
+getRequestClaim :: Http.RequestHeaders -> Http.Query -> POSIXTime -> Maybe JWT.Signer -> Either TokenError IcepeakClaim
 getRequestClaim headers query now maybeSecret =
   let getTokenBytes = maybe (Left $ VerificationError TokenNotFound) Right (findTokenBytes headers query)
   in case maybeSecret of
@@ -90,7 +90,7 @@ errorResponseBody = Aeson.encode
 
 -- * Middleware
 
-jwtMiddleware :: Maybe JWT.Secret -> Wai.Application -> Wai.Application
+jwtMiddleware :: Maybe JWT.Signer -> Wai.Application -> Wai.Application
 jwtMiddleware secret app req respond = do
     now <- Clock.getPOSIXTime
     case getRequestClaim headers query now secret of

--- a/server/src/Logger.hs
+++ b/server/src/Logger.hs
@@ -15,6 +15,7 @@ import Control.Monad (unless)
 import Control.Concurrent.STM (atomically)
 import Control.Concurrent.STM.TBQueue (TBQueue, newTBQueue, readTBQueue, writeTBQueue, isFullTBQueue)
 import Data.Text (Text)
+import GHC.Natural (Natural)
 import Prelude hiding (log)
 
 import qualified Data.Text.IO as T
@@ -27,7 +28,7 @@ data Logger = Logger { loggerQueue :: LogQueue }
 data LogCommand = LogRecord LogRecord | LogStop
   deriving (Eq, Ord, Show, Read)
 
-newLogger :: Int -> IO Logger
+newLogger :: Natural -> IO Logger
 newLogger queueSize = Logger <$> atomically (newTBQueue queueSize)
 
 -- | Post a non-essential log message to the queue. The message is discarded

--- a/server/stack.yaml
+++ b/server/stack.yaml
@@ -4,4 +4,3 @@ extra-deps:
   - prometheus-client-1.0.0
   - prometheus-metrics-ghc-1.0.0
   - wai-middleware-prometheus-1.0.0
-  - jwt-0.7.2

--- a/server/stack.yaml
+++ b/server/stack.yaml
@@ -4,3 +4,4 @@ extra-deps:
   - prometheus-client-1.0.0
   - prometheus-metrics-ghc-1.0.0
   - wai-middleware-prometheus-1.0.0
+  - jwt-0.7.2

--- a/server/stack.yaml
+++ b/server/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-12.6
+resolver: lts-14.0
 
 extra-deps:
   - prometheus-client-1.0.0

--- a/server/stack.yaml
+++ b/server/stack.yaml
@@ -1,6 +1,5 @@
 resolver: lts-14.0
 
 extra-deps:
-  - prometheus-client-1.0.0
   - prometheus-metrics-ghc-1.0.0
   - wai-middleware-prometheus-1.0.0

--- a/server/tests/JwtSpec.hs
+++ b/server/tests/JwtSpec.hs
@@ -40,11 +40,12 @@ spec = do
 
     let now = 12512 :: NominalDiffTime
 
-    let joseHeader = JWT.JOSEHeader {
-      JWT.typ = Just "JWT",
-      JWT.cty = Nothing,
-      JWT.alg = Just JWT.HS256,
-      JWT.kid = Nothing}
+    let joseHeader = JWT.JOSEHeader
+          { JWT.typ = Just "JWT"
+          , JWT.cty = Nothing
+          , JWT.alg = Just JWT.HS256
+          , JWT.kid = Nothing
+          }
 
     it "should accept a valid token" $ do
       let token = Text.encodeUtf8 $ JWT.encodeSigned testSecret joseHeader testClaims

--- a/server/tests/JwtSpec.hs
+++ b/server/tests/JwtSpec.hs
@@ -31,7 +31,7 @@ spec = do
           , JWT.nbf = Nothing
           , JWT.iat = Nothing
           , JWT.jti = Nothing
-          , JWT.unregisteredClaims = Map.empty
+          , JWT.unregisteredClaims = JWT.ClaimsMap Map.empty
           }
 
     let testClaims = addIcepeakClaim testAccess emptyClaim
@@ -40,30 +40,36 @@ spec = do
 
     let now = 12512 :: NominalDiffTime
 
+    let joseHeader = JWT.JOSEHeader {
+      JWT.typ = Just "JWT",
+      JWT.cty = Nothing,
+      JWT.alg = Just JWT.HS256,
+      JWT.kid = Nothing}
+
     it "should accept a valid token" $ do
-      let tok = Text.encodeUtf8 $ JWT.encodeSigned JWT.HS256 testSecret testClaims
-      extractClaim now testSecret tok `shouldBe` Right testAccess
+      let token = Text.encodeUtf8 $ JWT.encodeSigned testSecret joseHeader testClaims
+      extractClaim now testSecret token `shouldBe` Right testAccess
 
     it "should reject an expired token" $ do
       let Just expDate = JWT.numericDate $ now - 10
           claims = testClaims { JWT.exp = Just expDate }
-          expiredToken = Text.encodeUtf8 $ JWT.encodeSigned JWT.HS256 testSecret claims
+          expiredToken = Text.encodeUtf8 $ JWT.encodeSigned testSecret joseHeader claims
       extractClaim now testSecret expiredToken `shouldBe` Left (VerificationError TokenExpired)
 
     it "should reject a token before its 'not before' date" $ do
       let Just nbfDate = JWT.numericDate $ now + 10
           claims = testClaims { JWT.nbf = Just nbfDate }
-          nbfToken = Text.encodeUtf8 $ JWT.encodeSigned JWT.HS256 testSecret claims
+          nbfToken = Text.encodeUtf8 $ JWT.encodeSigned testSecret joseHeader claims
       extractClaim now testSecret nbfToken `shouldBe` Left (VerificationError TokenUsedTooEarly)
 
     it "should reject a token with wrong secret" $ do
       let claims = testClaims
-          nbfToken = Text.encodeUtf8 $ JWT.encodeSigned JWT.HS256 testSecret claims
+          nbfToken = Text.encodeUtf8 $ JWT.encodeSigned testSecret joseHeader claims
           otherSecret = JWT.HMACSecret "dfhwcmo845cm8e5"
       extractClaim now otherSecret nbfToken `shouldBe` Left (VerificationError TokenSignatureInvalid)
 
     prop "should correctly encode and decode token" $ \icepeakClaim ->
       let claims = addIcepeakClaim icepeakClaim emptyClaim
-          encoded = Text.encodeUtf8 $ JWT.encodeSigned JWT.HS256 testSecret claims
+          encoded = Text.encodeUtf8 $ JWT.encodeSigned testSecret joseHeader claims
           decoded = extractClaim now testSecret encoded
       in decoded == Right icepeakClaim

--- a/server/tests/JwtSpec.hs
+++ b/server/tests/JwtSpec.hs
@@ -36,7 +36,7 @@ spec = do
 
     let testClaims = addIcepeakClaim testAccess emptyClaim
 
-    let testSecret = JWT.binarySecret "2o8357cEuc2o835cmsoei"
+    let testSecret = JWT.HMACSecret "2o8357cEuc2o835cmsoei"
 
     let now = 12512 :: NominalDiffTime
 
@@ -59,7 +59,7 @@ spec = do
     it "should reject a token with wrong secret" $ do
       let claims = testClaims
           nbfToken = Text.encodeUtf8 $ JWT.encodeSigned JWT.HS256 testSecret claims
-          otherSecret = JWT.binarySecret "dfhwcmo845cm8e5"
+          otherSecret = JWT.HMACSecret "dfhwcmo845cm8e5"
       extractClaim now otherSecret nbfToken `shouldBe` Left (VerificationError TokenSignatureInvalid)
 
     prop "should correctly encode and decode token" $ \icepeakClaim ->


### PR DESCRIPTION
There were some breaking changes in `haskell-jwt` which was upgraded from
v0.7.2 to v0.10.0.

Notably:

```haskell
newtype Secret = Secret BS.ByteString
```

changed to

```haskell
data Signer = HMACSecret BS.ByteString
            | RSAPrivateKey PrivateKey
```

And

```haskell
type ClaimsMap = Map Text Value```
```

changed to

```haskell
newtype ClaimsMap = ClaimsMap { unClaimsMap :: Map.Map T.Text Value }
```

And

```haskell
encodeSigned :: Algorithm -> Secret -> JWTClaimsSet -> JSON
encodeUnsigned :: JWTClaimsSet -> JSON
```

changed to


```haskell
encodeSigned :: Signer -> JOSEHeader -> JWTClaimsSet -> Text
encodeUnsigned :: JWTClaimsSet -> JOSEHeader -> Text
```

Fortunately they documented all of this in their changelog, otherwise
I would have had to diff this with the help of `git log` /s