### PR TITLE
Make integration tests work with latest Stack

### DIFF
--- a/server/integration-tests/auth_stress_test.hs
+++ b/server/integration-tests/auth_stress_test.hs
@@ -1,5 +1,7 @@
 #!/usr/bin/env stack
--- stack --stack-yaml ../../client-haskell/stack.yaml runghc --package QuickCheck --package quickcheck-text -- -Wall
+-- stack --stack-yaml ../../client-haskell/stack.yaml runghc --package QuickCheck --package quickcheck-text
+
+{-# OPTIONS_GHC -Wall #-}
 
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}

--- a/server/integration-tests/generate_test_token.hs
+++ b/server/integration-tests/generate_test_token.hs
@@ -1,5 +1,7 @@
 #!/usr/bin/env stack
--- stack --stack-yaml ../../server/stack.yaml runghc --package QuickCheck --package quickcheck-text -- -Wall
+-- stack --stack-yaml ../../server/stack.yaml runghc --package QuickCheck --package quickcheck-text --package icepeak
+
+{-# OPTIONS_GHC -Wall #-}
 
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}

--- a/server/integration-tests/stress_test.hs
+++ b/server/integration-tests/stress_test.hs
@@ -1,5 +1,7 @@
 #!/usr/bin/env stack
--- stack --stack-yaml ../../client-haskell/stack.yaml runghc --package QuickCheck --package quickcheck-text -- -Wall
+-- stack --stack-yaml ../../client-haskell/stack.yaml runghc --package QuickCheck --package quickcheck-text --package icepeak-client
+
+{-# OPTIONS_GHC -Wall #-}
 
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}


### PR DESCRIPTION
For some reason the behavior of stack runghc changed and we have to pass icepeak{,-client} explicitly and not pass GHC options.

GHC options are now passed with OPTIONS_GHC.