### PR TITLE
Fix/unkownhttp

### DIFF
--- a/server/package.yaml
+++ b/server/package.yaml
@@ -52,6 +52,7 @@ library:
   - AccessControl
   - Config
   - Core
+  - HTTPMethodInvalid
   - HttpServer
   - JwtAuth
   - JwtMiddleware
@@ -93,6 +94,7 @@ tests:
     - hspec
     - hspec-core
     - hspec-expectations
+    - hspec-wai
     - QuickCheck
     - quickcheck-instances
     - icepeak

--- a/server/src/HTTPMethodInvalid.hs
+++ b/server/src/HTTPMethodInvalid.hs
@@ -9,6 +9,7 @@ import qualified Data.ByteString.Lazy.Char8 as LBS
 -- | Checks that the HTTP method is one of the StdMethods.
 -- StdMethod: HTTP standard method (as defined by RFC 2616, and PATCH which is defined by RFC 5789).
 -- Otherwise sets the HTTP method to INVALID.
+-- post: HTTP method is canonicalized
 canonicalizeHTTPMethods :: Wai.Middleware
 canonicalizeHTTPMethods app request respond = do
   let method = Wai.requestMethod request
@@ -17,7 +18,7 @@ canonicalizeHTTPMethods app request respond = do
   app request' respond
 
 -- | Early exit for INVALID HTTP methods.
--- pre: HTTP method is canonicalized
+-- pre: HTTP method is canonicalized.
 limitHTTPMethods :: Wai.Middleware
 limitHTTPMethods app request respond =
   if Wai.requestMethod request == invalid

--- a/server/src/HTTPMethodInvalid.hs
+++ b/server/src/HTTPMethodInvalid.hs
@@ -1,0 +1,28 @@
+module HTTPMethodInvalid (canonicalizeHTTPMethods, limitHTTPMethods) where
+
+import qualified Network.Wai as Wai
+import qualified Network.HTTP.Types as HTTP
+import qualified Network.HTTP.Types.Method as Method
+import qualified Data.ByteString.Char8 as ByteString
+import qualified Data.ByteString.Lazy.Char8 as LBS
+
+-- Checks that the HTTP method is one of the StdMethods.
+-- StdMethod: HTTP standard method (as defined by RFC 2616, and PATCH which is defined by RFC 5789).
+-- Otherwise sets the HTTP method to INVALID.
+canonicalizeHTTPMethods :: Wai.Middleware
+canonicalizeHTTPMethods app request respond = do
+  let method = Wai.requestMethod request
+      parsedMethod = either (\_ -> invalid) (Method.renderStdMethod) (Method.parseMethod method)
+      request' = request { Wai.requestMethod = parsedMethod }
+  app request' respond
+
+-- Early exit for INVALID HTTP methods.
+-- pre: HTTP method is canonicalized
+limitHTTPMethods :: Wai.Middleware
+limitHTTPMethods app request respond =
+  if Wai.requestMethod request == invalid
+    then respond (Wai.responseLBS HTTP.badRequest400 [(HTTP.hContentType, (ByteString.pack "application/json"))] (LBS.pack "{}"))
+    else app request respond
+
+invalid :: Method.Method
+invalid = ByteString.pack "INVALID"

--- a/server/src/HTTPMethodInvalid.hs
+++ b/server/src/HTTPMethodInvalid.hs
@@ -6,7 +6,7 @@ import qualified Network.HTTP.Types.Method as Method
 import qualified Data.ByteString.Char8 as ByteString
 import qualified Data.ByteString.Lazy.Char8 as LBS
 
--- Checks that the HTTP method is one of the StdMethods.
+-- | Checks that the HTTP method is one of the StdMethods.
 -- StdMethod: HTTP standard method (as defined by RFC 2616, and PATCH which is defined by RFC 5789).
 -- Otherwise sets the HTTP method to INVALID.
 canonicalizeHTTPMethods :: Wai.Middleware
@@ -16,7 +16,7 @@ canonicalizeHTTPMethods app request respond = do
       request' = request { Wai.requestMethod = parsedMethod }
   app request' respond
 
--- Early exit for INVALID HTTP methods.
+-- | Early exit for INVALID HTTP methods.
 -- pre: HTTP method is canonicalized
 limitHTTPMethods :: Wai.Middleware
 limitHTTPMethods app request respond =

--- a/server/src/HttpServer.hs
+++ b/server/src/HttpServer.hs
@@ -35,7 +35,7 @@ new core =
     -- Second middleware is the metrics middleware in order to intercept
     -- all requests and their corresponding responses
     forM_ (coreMetrics core) $ middleware . metricsMiddleware
-    -- Early out after the request has been stored in the metrics.
+    -- Exit on unknown HTTP verb after the request has been stored in the metrics.
     middleware limitHTTPMethods
     -- Use the Sentry logger if available
     -- Scottys error handler will only catch errors that are thrown from within

--- a/server/tests/ApiSpec.hs
+++ b/server/tests/ApiSpec.hs
@@ -4,7 +4,3 @@ import Test.Hspec
 
 spec :: Spec
 spec = return ()
-  -- do
-  -- describe "Api" $ do
-  --   it "should be true" $ do
-  --     True

--- a/server/tests/ApiSpec.hs
+++ b/server/tests/ApiSpec.hs
@@ -1,10 +1,10 @@
 module ApiSpec (spec) where
 
-import Test.Hspec (Spec, describe, it)
+import Test.Hspec
 
 spec :: Spec
-spec = do
-  describe "Api" $ do
-
-    it "should be true" $ do
-      True
+spec = return ()
+  -- do
+  -- describe "Api" $ do
+  --   it "should be true" $ do
+  --     True

--- a/server/tests/RequestSpec.hs
+++ b/server/tests/RequestSpec.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE OverloadedStrings #-}
+module RequestSpec (spec) where
+
+import           Test.Hspec
+import           Test.Hspec.Wai
+
+import           HTTPMethodInvalid (canonicalizeHTTPMethods, limitHTTPMethods)
+
+import qualified Network.HTTP.Types as HTTP
+import qualified Network.Wai as Wai
+
+import qualified Data.ByteString.Char8 as ByteString
+
+spec :: Spec
+spec = describe "Request method" $ with (pure app) $ do
+  it "accepts method get" $ do
+    (request HTTP.methodGet "/" [] "") `shouldRespondWith` 200
+  it "accepts method post" $ do
+    (request HTTP.methodPost "/" [] "") `shouldRespondWith` 200
+  it "accepts method head" $ do
+    (request HTTP.methodHead "/" [] "") `shouldRespondWith` 200
+  it "accepts method put" $ do
+    (request HTTP.methodPut "/" [] "") `shouldRespondWith` 200
+  it "accepts method delete" $ do
+    (request HTTP.methodDelete "/" [] "") `shouldRespondWith` 200
+  it "accepts method trace" $ do
+    (request HTTP.methodTrace "/" [] "") `shouldRespondWith` 200
+  it "accepts method connect" $ do
+    (request HTTP.methodConnect "/" [] "") `shouldRespondWith` 200
+  it "accepts method options" $ do
+    (request HTTP.methodOptions "/" [] "") `shouldRespondWith` 200
+  it "accepts method patch" $ do
+    (request HTTP.methodPatch "/" [] "") `shouldRespondWith` 200
+
+  it "declines other methods yqus" $ do
+    (request yqus "/" [] "") `shouldRespondWith` 400
+  it "declines other methods badmethod" $ do
+    (request badMethod "/" [] "") `shouldRespondWith` 400
+  it "declines other methods invalid" $ do
+    (request invalid "/" [] "") `shouldRespondWith` 400
+
+app :: Wai.Application
+app = (canonicalizeHTTPMethods . limitHTTPMethods) return200
+
+return200 :: Wai.Application
+return200 _ respond = respond $
+    Wai.responseLBS HTTP.status200 [("Content-Type", "text/plain")] ""
+
+yqus :: HTTP.Method
+yqus = ByteString.pack "YQUS"
+
+badMethod :: HTTP.Method
+badMethod = ByteString.pack "BADMETHOD"
+
+invalid :: HTTP.Method
+invalid = ByteString.pack "INVALID"

--- a/server/tests/SocketSpec.hs
+++ b/server/tests/SocketSpec.hs
@@ -1,6 +1,6 @@
 module SocketSpec (spec) where
 
-import Test.Hspec (Spec, describe, it)
+import Test.Hspec
 
 spec :: Spec
 spec = return ()

--- a/server/tests/SocketSpec.hs
+++ b/server/tests/SocketSpec.hs
@@ -3,9 +3,9 @@ module SocketSpec (spec) where
 import Test.Hspec (Spec, describe, it)
 
 spec :: Spec
-spec = do
-  describe "Socket" $ do
-
-    it "should be true" $ do
-      True
+spec = return ()
+  -- do
+  -- describe "Socket" $ do
+  --   it "should be true" $ do
+  --     True
 

--- a/server/tests/SocketSpec.hs
+++ b/server/tests/SocketSpec.hs
@@ -4,8 +4,3 @@ import Test.Hspec
 
 spec :: Spec
 spec = return ()
-  -- do
-  -- describe "Socket" $ do
-  --   it "should be true" $ do
-  --     True
-

--- a/server/tests/Spec.hs
+++ b/server/tests/Spec.hs
@@ -5,6 +5,7 @@ import qualified ApiSpec
 import qualified CoreSpec
 import qualified JwtSpec
 import qualified PersistenceSpec
+import qualified RequestSpec
 import qualified SocketSpec
 import qualified StoreSpec
 import qualified SubscriptionTreeSpec
@@ -16,6 +17,7 @@ main = hspec $ do
   CoreSpec.spec
   JwtSpec.spec
   PersistenceSpec.spec
+  RequestSpec.spec
   SocketSpec.spec
   StoreSpec.spec
   SubscriptionTreeSpec.spec


### PR DESCRIPTION
Canonicalize invalid http methods to `INVALID`.
Limit the invalid http requests.