### PR TITLE
Upgrade stack from LTS 14.0 to LTS 14.20

### DIFF
--- a/client-haskell/stack.yaml
+++ b/client-haskell/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-14.0
+resolver: lts-14.20

--- a/server/src/WebsocketServer.hs
+++ b/server/src/WebsocketServer.hs
@@ -72,11 +72,11 @@ acceptConnection core pending = do
         }
     AuthAccepted -> do
       let path = fst $ Uri.decodePath $ WS.requestPath $ WS.pendingRequest pending
-      conn <- WS.acceptRequest pending
-      -- Fork a pinging thread to keep idle connections open and to detect closed connections.
+      connection <- WS.acceptRequest pending
+      -- Fork a pinging thread, for each client, to keep idle connections open and to detect
+      -- closed connections. Sends a ping message every 30 seconds.
       -- Note: The thread dies silently if the connection crashes or is closed.
-      WS.forkPingThread conn 30
-      handleClient conn path core
+      WS.withPingThread connection 30 (pure ()) $ handleClient connection path core
 
 -- * Authorization
 

--- a/server/stack.yaml
+++ b/server/stack.yaml
@@ -1,6 +1,6 @@
-resolver: lts-14.0
+resolver: lts-14.20
 
 extra-deps:
-  - raven-haskell-0.1.2.0
+  - raven-haskell-0.1.2.1
   - prometheus-metrics-ghc-1.0.0
   - wai-middleware-prometheus-1.0.0


### PR DESCRIPTION
There was one API change in the websockets library. The `forkPingThread`
function is now deprecated and has been replaced by the `withPingThread`
function. The latter one uses `withAsync` instead of `forkIO`, which the
former one used. This is only an internal change and has no externally
visible effects.