### PR TITLE
Build/package with Nix

### DIFF
--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,0 +1,8 @@
+let
+  rev = "b937c4c734afffe5cf7bf83d1f85e861b7a8c68c";
+  tarball = fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+    sha256 = "sha256:1w7qi0kan6afr6iz1rkwmij3isdvvc3cmx1jj5hqj6p7d9lcdb3n";
+  };
+in
+  import tarball

--- a/nix/websockets.nix
+++ b/nix/websockets.nix
@@ -1,0 +1,57 @@
+{ HUnit
+, QuickCheck
+, SHA
+, async
+, attoparsec
+, base
+, base64-bytestring
+, binary
+, bytestring
+, bytestring-builder
+, case-insensitive
+, clock
+, containers
+, criterion
+, entropy
+, mkDerivation
+, network
+, random
+, stdenv
+, streaming-commons
+, test-framework
+, test-framework-hunit
+, test-framework-quickcheck2
+, text
+}:
+
+mkDerivation {
+  pname = "websockets";
+  version = "0.12.7.0";
+  sha256 = "11jz0d7hgbl449dvz789gyf85gdwm6h0klq05vilmplpdx61h4az";
+
+  isLibrary = true;
+  isExecutable = true;
+
+  libraryHaskellDepends = [
+    SHA
+    async
+    attoparsec
+    base
+    base64-bytestring
+    binary
+    bytestring
+    bytestring-builder
+    case-insensitive
+    clock
+    containers
+    entropy
+    network
+    random
+    streaming-commons
+    text
+  ];
+
+  doCheck = false;
+  description = "A sensible and clean way to write WebSocket-capable servers in Haskell";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -30,3 +30,6 @@ icepeak.json.journal
 icepeak.json.new
 *.idea
 *.iml
+
+# Nix result symlinks
+result*

--- a/server/default.nix
+++ b/server/default.nix
@@ -1,5 +1,17 @@
 let
-  pkgs = import ../nix/nixpkgs.nix {};
-  icepeak-server = pkgs.haskellPackages.callPackage ./server.nix {};
+  config = {
+    packageOverrides = pkgs: rec {
+      haskellPackages = pkgs.haskellPackages.override {
+        overrides = haskellPackagesNew: haskellPackagesOld: rec {
+          icepeak = haskellPackagesNew.callPackage ./server.nix { };
+          websockets = haskellPackagesNew.callPackage ../nix/websockets.nix { };
+        };
+      };
+    };
+  };
+
+  pkgs = import ../nix/nixpkgs.nix { inherit config; };
 in
-  icepeak-server
+  {
+    icepeak-server = pkgs.haskellPackages.icepeak;
+  }

--- a/server/default.nix
+++ b/server/default.nix
@@ -1,0 +1,5 @@
+let
+  pkgs = import ../nix/nixpkgs.nix {};
+  icepeak-server = pkgs.haskellPackages.callPackage ./server.nix {};
+in
+  icepeak-server

--- a/server/default.nix
+++ b/server/default.nix
@@ -1,3 +1,10 @@
+{ # We expect getPkgs to be a lambda that gives us a package set. Example:
+  # the lambda in `nixpkgs/default.nix` without any arguments passed to it.
+  # That allows us to pass in config later, while allowing users to pass in
+  # their own version of Nixpkgs.
+  getPkgs ? import ../nix/nixpkgs.nix
+}:
+
 let
   config = {
     packageOverrides = pkgs: rec {
@@ -10,7 +17,7 @@ let
     };
   };
 
-  pkgs = import ../nix/nixpkgs.nix { inherit config; };
+  pkgs = getPkgs { inherit config; };
 in
   {
     icepeak-server = pkgs.haskellPackages.icepeak;

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -1,5 +1,5 @@
 name: icepeak
-version: '0.6.2'
+version: '0.6.3'
 synopsis: Icepeak is a fast JSON document store with push notification support
 license: BSD3
 homepage: https://github.com/channable/icepeak

--- a/server/server.nix
+++ b/server/server.nix
@@ -41,7 +41,7 @@
 
 mkDerivation {
   pname = "icepeak";
-  version = "0.6.2";
+  version = "0.6.3";
 
   # Opt in to hpack. We don't commit the cabal file in our repo currently.
   buildTools = [ hpack ];

--- a/server/server.nix
+++ b/server/server.nix
@@ -5,6 +5,7 @@
 , containers
 , directory
 , hashable
+, hpack
 , hspec
 , hspec-wai
 , http-types
@@ -41,6 +42,10 @@
 mkDerivation {
   pname = "icepeak";
   version = "0.6.2";
+
+  # Opt in to hpack. We don't commit the cabal file in our repo currently.
+  buildTools = [ hpack ];
+  preConfigure = "hpack .";
 
   src =
     let

--- a/server/server.nix
+++ b/server/server.nix
@@ -41,7 +41,56 @@
 mkDerivation {
   pname = "icepeak";
   version = "0.6.2";
-  src = ./.;
+
+  src =
+    let
+      # Naive whitelist of file function. We could make this nicer eventually,
+      # but this works. This also makes it obvious we do not run the integration
+      # tests as part of building.
+      srcPaths = builtins.map builtins.toString [
+        ./package.yaml
+
+        ./tests
+        ./tests/AccessControlSpec.hs
+        ./tests/ApiSpec.hs
+        ./tests/CoreSpec.hs
+        ./tests/JwtSpec.hs
+        ./tests/OrphanInstances.hs
+        ./tests/PersistenceSpec.hs
+        ./tests/RequestSpec.hs
+        ./tests/SocketSpec.hs
+        ./tests/Spec.hs
+        ./tests/StoreSpec.hs
+        ./tests/SubscriptionTreeSpec.hs
+
+        ./src
+        ./src/AccessControl.hs
+        ./src/Config.hs
+        ./src/Core.hs
+        ./src/HTTPMethodInvalid.hs
+        ./src/HttpServer.hs
+        ./src/JwtAuth.hs
+        ./src/JwtMiddleware.hs
+        ./src/Logger.hs
+        ./src/Metrics.hs
+        ./src/MetricsServer.hs
+        ./src/Persistence.hs
+        ./src/SentryLogging.hs
+        ./src/Server.hs
+        ./src/Store.hs
+        ./src/Subscription.hs
+        ./src/WebsocketServer.hs
+
+        ./app
+        ./app/Icepeak
+        ./app/Icepeak/Main.hs
+        ./app/IcepeakTokenGen
+        ./app/IcepeakTokenGen/Main.hs
+      ];
+    in
+      builtins.filterSource
+        (path: (type: builtins.elem path srcPaths))
+        ./.;
 
   isLibrary = false;
   isExecutable = true;

--- a/server/server.nix
+++ b/server/server.nix
@@ -1,0 +1,92 @@
+{ aeson
+, async
+, base
+, bytestring
+, containers
+, directory
+, hashable
+, hspec
+, hspec-wai
+, http-types
+, jwt
+, mkDerivation
+, monad-logger
+, mtl
+, network
+, optparse-applicative
+, prometheus-client
+, prometheus-metrics-ghc
+, QuickCheck
+, quickcheck-instances
+, random
+, raven-haskell
+, scotty
+, sqlite-simple
+, securemem
+, stdenv
+, stm
+, text
+, time
+, unix
+, unordered-containers
+, uuid
+, wai
+, wai-extra
+, wai-middleware-prometheus
+, wai-websockets
+, warp
+, websockets
+}:
+
+mkDerivation {
+  pname = "icepeak";
+  version = "0.6.2";
+  src = ./.;
+
+  isLibrary = false;
+  isExecutable = true;
+
+  executableHaskellDepends = [
+    aeson
+    async
+    base
+    bytestring
+    containers
+    directory
+    hashable
+    http-types
+    jwt
+    monad-logger
+    mtl
+    network
+    optparse-applicative
+    prometheus-client
+    prometheus-metrics-ghc
+    random
+    raven-haskell
+    scotty
+    sqlite-simple
+    securemem
+    stm
+    text
+    time
+    unix
+    unordered-containers
+    uuid
+    wai
+    wai-extra
+    wai-middleware-prometheus
+    wai-websockets
+    warp
+    websockets
+  ];
+
+  testHaskellDepends = [
+    hspec
+    hspec-wai
+    QuickCheck
+    quickcheck-instances
+  ];
+
+  license = stdenv.lib.licenses.bsd3;
+}


### PR DESCRIPTION
Add a Nix package definition for Icepeak.

```
$ cd server
$ nix build
```

### Background

Nix is a purely functional build system. It can be used to build software and their dependencies. Read [The Nix Ecosystem](https://nixos.wiki/wiki/Nix_Ecosystem) for a high level introduction.

This PR uses Nix to build Icepeak. Nix and the extended Nix ecosystem enable us to define the exact dependencies that were used in order to build a package.

Internally, Channable is starting to use Nix for more things. This PR is part of our efforts to gain more experience in using Nix for all types of software. This PR might also help us easily build and distribute icepeak binaries.

Read https://nixos.org/nixos/nix-pills/ for an introduction to the Nix language and to derivations.

### Background: What's in Nixpkgs?

Nixpkgs contains a large collection of software ranging from applications to development tooling. It also contains a set of Haskell packages (similar to Stackage).

The things you need to know are:

 - Nixpkgs is generally pinned to a specific commit for reproducibility. By convention, the entirety of nixpkgs is generally imported as `pkgs`.
 - Nixpkgs contains infrastructure for building Haskell packages. This functionality is available under `pkgs.haskellPackages`. This [attribute set](https://nixos.wiki/wiki/Nix_Expression_Language#Types) contains packages themselves, as well as functions for constructing more of them. The most notable one we use in this PR is `pkgs.haskellPackages.callPackage` and `pkgs.haskellPackages.mkDerivation`.

### Approach

This PR adds 4 new files:

 - Pin a specific version of Nixpkgs in `nix/nixpkgs.nix`. This helps with reproducibility.
 - Specify packages in `server.nix` and `nix/websockets.nix`. These files contain a function with type `AttrSet -> Derivation`. They expect a set of dependencies to be passed to them so they can eventually build a derivation out of them.
 - Wire everything up in `default.nix`. This is the trickiest bit.

### On `default.nix`

The short version: we only want to compile against a single version of a library like `websockets`. Therefore we need to override it on the Haskell package set from Nixpkgs. We cannot just pass the new version to `icepeak` itself as we might also transitively depend on `websockets` through something else.

The boilerplate in `default.nix` overrides `pkgs.haskellPackages.websockets` for `icepeak` **and** for all other packages in `pkgs.haskellPackages`. Nixpkgs has utilities which ensure that everything works out.

While we're at it, we also include `icepeak` in the overriden set of Haskell packages. That would only be useful if other packages from Nixpkgs ever add a dependency on Icepeak, but that's apparently good practice.

For more background and tutorials, I can recommend https://github.com/Gabriel439/haskell-nix/

### Results

We get a dynamic executable out of the build process which does what we want.

Next steps include:

 - Improving the `src` directive (currently this leads to excessive rebuilds)
 - Building this on CI
 - Upstreaming to Nixpkgs if we like.