### PR TITLE
nix: Actually include client module in derivation

### DIFF
--- a/client-haskell/client.nix
+++ b/client-haskell/client.nix
@@ -24,7 +24,8 @@ mkDerivation {
       srcPaths = builtins.map builtins.toString [
           ./package.yaml
           ./src
-          ./src/Client.hs
+          ./src/Icepeak
+          ./src/Icepeak/Client.hs
       ];
     in
       builtins.filterSource

--- a/client-haskell/package.yaml
+++ b/client-haskell/package.yaml
@@ -22,3 +22,5 @@ dependencies:
 
 library:
   source-dirs: src
+  exposed-modules:
+  - Icepeak.Client


### PR DESCRIPTION
It built before, but it was just an empty library. It wasn't detected because we didn't explicitly specify the modules in `package.yaml`, leaving it for hpack to discover which modules there are.