### PR TITLE
Upgrade stack from LTS 14.23 to 15.3

### DIFF
--- a/client-haskell/stack.yaml
+++ b/client-haskell/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-14.23
+resolver: lts-15.3

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -16,7 +16,7 @@ ghc-options:
 dependencies:
 - aeson                             >= 1.4.6 && < 1.5
 - async                             >= 2.2.2 && < 2.3
-- base                              >= 4.12.0 && < 4.13
+- base                              >= 4.12.0 && < 4.14
 - bytestring                        >= 0.10.8 && < 0.11
 - containers                        >= 0.6.0 && < 0.7
 - directory                         >= 1.3.3 && < 1.4
@@ -36,7 +36,7 @@ dependencies:
 - sqlite-simple                     >= 0.4.16 && < 0.5
 - stm                               >= 2.5.0 && < 2.6
 - text                              >= 1.2.3 && < 1.3
-- time                              >= 1.8.0 && < 1.9
+- time                              >= 1.8.0 && < 1.10
 - unix                              >= 2.7.2 && < 2.8
 - unordered-containers              >= 0.2.10 && < 0.3
 - uuid                              >= 1.3.13 && < 1.4

--- a/server/stack.yaml
+++ b/server/stack.yaml
@@ -1,6 +1,8 @@
-resolver: lts-14.23
+resolver: lts-15.3
 
 extra-deps:
   - raven-haskell-0.1.2.1
   - prometheus-metrics-ghc-1.0.0
   - wai-middleware-prometheus-1.0.0
+  - sqlite-simple-0.4.18.0
+  - direct-sqlite-2.3.26


### PR DESCRIPTION
This also upgrades GHC from 8.6 to 8.8. There have been no breaking
changes and the tests are still passing. I did have to add sqlite-simple
and direct-sqlite as extra-deps, since they are no longer in the
stackage snapshot.

Why upgrade?

I have been on a [quixotic quest](https://github.com/NixOS/nixpkgs/pull/79155) to get Icepeak added to the Nixpkgs archive. And nixpkgs recently upgraded their supported GHC version from 8.6 to 8.8, and it's therefore necessary to upgrade here as well, because I can then release a new version of Icepeak on Hackage, which can then be downloaded by an automatic script `hackage2nix`, which will generate a Nix derivation for Icepeak, that is then added to Nixpkgs. :see_no_evil: 