### PR TITLE
Add metrics with recommended Prometheus naming scheme

### DIFF
--- a/server/src/Metrics.hs
+++ b/server/src/Metrics.hs
@@ -25,21 +25,25 @@ countHttpRequest method status httpRequestCounter = withLabel httpRequestCounter
 
 
 data IcepeakMetrics = IcepeakMetrics
-  { icepeakMetricsRequestCounter  :: HttpRequestCounter
-  , icepeakMetricsDataSize        :: Gauge
-  , icepeakMetricsJournalSize     :: Gauge
-  , icepeakMetricsDataWritten     :: Counter
-  , icepeakMetricsJournalWritten  :: Counter
-  , icepeakMetricsSubscriberCount :: Gauge
+  { icepeakMetricsRequestCounter    :: HttpRequestCounter
+  , icepeakMetricsDataSize          :: Gauge
+  , icepeakMetricsDataSizeBytes     :: Gauge
+  , icepeakMetricsJournalSize       :: Gauge
+  , icepeakMetricsDataWritten       :: Counter
+  , icepeakMetricsDataWrittenTotal  :: Counter
+  , icepeakMetricsJournalWritten    :: Counter
+  , icepeakMetricsSubscriberCount   :: Gauge
   }
 
 createAndRegisterIcepeakMetrics :: IO IcepeakMetrics
 createAndRegisterIcepeakMetrics = IcepeakMetrics
   <$> register (vector ("method", "status") requestCounter)
   <*> register (gauge (Info "icepeak_data_size" "Size of data file in bytes."))
+  <*> register (gauge (Info "icepeak_data_size_bytes" "Size of data file in bytes."))
   <*> register (gauge (Info "icepeak_journal_size_bytes"
                             "Size of journal file in bytes."))
   <*> register (counter (Info "icepeak_data_written" "Total number of bytes written so far."))
+  <*> register (counter (Info "icepeak_data_written_bytes_total" "Total number of bytes written so far."))
   <*> register (counter (Info "icepeak_journal_written_bytes_total"
                               "Total number of bytes written to the journal so far."))
   <*> register (gauge
@@ -52,7 +56,9 @@ notifyRequest :: Http.Method -> Http.Status -> IcepeakMetrics -> IO ()
 notifyRequest method status = countHttpRequest method status . icepeakMetricsRequestCounter
 
 setDataSize :: (MonadMonitor m, Real a) => a -> IcepeakMetrics -> m ()
-setDataSize val metrics = setGauge (icepeakMetricsDataSize metrics) (realToFrac val)
+setDataSize val metrics = do
+  setGauge (icepeakMetricsDataSize      metrics) (realToFrac val)
+  setGauge (icepeakMetricsDataSizeBytes metrics) (realToFrac val)
 
 setJournalSize :: (MonadMonitor m, Real a) => a -> IcepeakMetrics -> m ()
 setJournalSize val metrics = setGauge (icepeakMetricsJournalSize metrics) (realToFrac val)
@@ -60,8 +66,9 @@ setJournalSize val metrics = setGauge (icepeakMetricsJournalSize metrics) (realT
 -- | Increment the total data written to disk by the given number of bytes.
 -- Returns True, when it actually increased the counter and otherwise False.
 incrementDataWritten :: (MonadMonitor m, Real a) => a -> IcepeakMetrics -> m Bool
-incrementDataWritten num_bytes metrics = addCounter (icepeakMetricsDataWritten metrics)
-  (realToFrac num_bytes)
+incrementDataWritten num_bytes metrics = do
+  addCounter (icepeakMetricsDataWritten      metrics) (realToFrac num_bytes)
+  addCounter (icepeakMetricsDataWrittenTotal metrics) (realToFrac num_bytes)
 
 -- | Increment the data written to the journal by the given number of bytes.
 -- Returns True, when it actually increased the counter and otherwise False.

--- a/server/src/Metrics.hs
+++ b/server/src/Metrics.hs
@@ -67,7 +67,7 @@ setJournalSize val metrics = setGauge (icepeakMetricsJournalSize metrics) (realT
 -- Returns True, when it actually increased the counter and otherwise False.
 incrementDataWritten :: (MonadMonitor m, Real a) => a -> IcepeakMetrics -> m Bool
 incrementDataWritten num_bytes metrics = do
-  addCounter (icepeakMetricsDataWritten      metrics) (realToFrac num_bytes)
+  _ <- addCounter (icepeakMetricsDataWritten metrics) (realToFrac num_bytes) -- Ignore the result to silence linter
   addCounter (icepeakMetricsDataWrittenTotal metrics) (realToFrac num_bytes)
 
 -- | Increment the data written to the journal by the given number of bytes.

--- a/server/src/Metrics.hs
+++ b/server/src/Metrics.hs
@@ -26,7 +26,8 @@ countHttpRequest method status httpRequestCounter = withLabel httpRequestCounter
 
 data IcepeakMetrics = IcepeakMetrics
   { icepeakMetricsRequestCounter    :: HttpRequestCounter
-  , icepeakMetricsDataSize          :: Gauge -- TODO: can be removed after dashboard has been updated to use icepeak_data_size_bytes
+  -- TODO: the following line can be removed after dashboard has been updated to use icepeak_data_size_bytes
+  , icepeakMetricsDataSize          :: Gauge
   , icepeakMetricsDataSizeBytes     :: Gauge
   , icepeakMetricsJournalSize       :: Gauge
   , icepeakMetricsDataWritten       :: Counter
@@ -38,11 +39,13 @@ data IcepeakMetrics = IcepeakMetrics
 createAndRegisterIcepeakMetrics :: IO IcepeakMetrics
 createAndRegisterIcepeakMetrics = IcepeakMetrics
   <$> register (vector ("method", "status") requestCounter)
-  <*> register (gauge (Info "icepeak_data_size" "Size of data file in bytes.")) -- TODO: can be removed after dashboard has been updated to use icepeak_data_size_bytes
+  -- TODO: the following line can be removed after dashboard has been updated to use icepeak_data_size_bytes
+  <*> register (gauge (Info "icepeak_data_size" "Size of data file in bytes."))
   <*> register (gauge (Info "icepeak_data_size_bytes" "Size of data file in bytes."))
   <*> register (gauge (Info "icepeak_journal_size_bytes"
                             "Size of journal file in bytes."))
-  <*> register (counter (Info "icepeak_data_written" "Total number of bytes written so far.")) -- TODO: can be removed after dashboard has been updated to use icepeak_data_written_bytes_total
+  -- TODO: the following line can be removed after dashboard has been updated to use icepeak_data_size_bytes
+  <*> register (counter (Info "icepeak_data_written" "Total number of bytes written so far."))
   <*> register (counter (Info "icepeak_data_written_bytes_total" "Total number of bytes written so far."))
   <*> register (counter (Info "icepeak_journal_written_bytes_total"
                               "Total number of bytes written to the journal so far."))
@@ -57,7 +60,8 @@ notifyRequest method status = countHttpRequest method status . icepeakMetricsReq
 
 setDataSize :: (MonadMonitor m, Real a) => a -> IcepeakMetrics -> m ()
 setDataSize val metrics = do
-  setGauge (icepeakMetricsDataSize      metrics) (realToFrac val) -- TODO: can be removed after dashboard has been updated to use icepeak_data_size_bytes
+  -- TODO: the following line can be removed after dashboard has been updated to use icepeak_data_size_bytes
+  setGauge (icepeakMetricsDataSize      metrics) (realToFrac val)
   setGauge (icepeakMetricsDataSizeBytes metrics) (realToFrac val)
 
 setJournalSize :: (MonadMonitor m, Real a) => a -> IcepeakMetrics -> m ()
@@ -67,7 +71,9 @@ setJournalSize val metrics = setGauge (icepeakMetricsJournalSize metrics) (realT
 -- Returns True, when it actually increased the counter and otherwise False.
 incrementDataWritten :: (MonadMonitor m, Real a) => a -> IcepeakMetrics -> m Bool
 incrementDataWritten num_bytes metrics = do
-  _ <- addCounter (icepeakMetricsDataWritten metrics) (realToFrac num_bytes) -- Ignore the result to silence linter. TODO: can be removed after dashboard has been updated to use icepeak_data_written_bytes_total
+  -- Ignore the result to silence linter.
+  -- TODO: the following line can be removed after dashboard has been updated to use icepeak_data_size_bytes
+  _ <- addCounter (icepeakMetricsDataWritten metrics) (realToFrac num_bytes)
   addCounter (icepeakMetricsDataWrittenTotal metrics) (realToFrac num_bytes)
 
 -- | Increment the data written to the journal by the given number of bytes.

--- a/server/src/Metrics.hs
+++ b/server/src/Metrics.hs
@@ -26,7 +26,7 @@ countHttpRequest method status httpRequestCounter = withLabel httpRequestCounter
 
 data IcepeakMetrics = IcepeakMetrics
   { icepeakMetricsRequestCounter    :: HttpRequestCounter
-  , icepeakMetricsDataSize          :: Gauge
+  , icepeakMetricsDataSize          :: Gauge -- TODO: can be removed after dashboard has been updated to use icepeak_data_size_bytes
   , icepeakMetricsDataSizeBytes     :: Gauge
   , icepeakMetricsJournalSize       :: Gauge
   , icepeakMetricsDataWritten       :: Counter
@@ -38,11 +38,11 @@ data IcepeakMetrics = IcepeakMetrics
 createAndRegisterIcepeakMetrics :: IO IcepeakMetrics
 createAndRegisterIcepeakMetrics = IcepeakMetrics
   <$> register (vector ("method", "status") requestCounter)
-  <*> register (gauge (Info "icepeak_data_size" "Size of data file in bytes."))
+  <*> register (gauge (Info "icepeak_data_size" "Size of data file in bytes.")) -- TODO: can be removed after dashboard has been updated to use icepeak_data_size_bytes
   <*> register (gauge (Info "icepeak_data_size_bytes" "Size of data file in bytes."))
   <*> register (gauge (Info "icepeak_journal_size_bytes"
                             "Size of journal file in bytes."))
-  <*> register (counter (Info "icepeak_data_written" "Total number of bytes written so far."))
+  <*> register (counter (Info "icepeak_data_written" "Total number of bytes written so far.")) -- TODO: can be removed after dashboard has been updated to use icepeak_data_written_bytes_total
   <*> register (counter (Info "icepeak_data_written_bytes_total" "Total number of bytes written so far."))
   <*> register (counter (Info "icepeak_journal_written_bytes_total"
                               "Total number of bytes written to the journal so far."))
@@ -57,7 +57,7 @@ notifyRequest method status = countHttpRequest method status . icepeakMetricsReq
 
 setDataSize :: (MonadMonitor m, Real a) => a -> IcepeakMetrics -> m ()
 setDataSize val metrics = do
-  setGauge (icepeakMetricsDataSize      metrics) (realToFrac val)
+  setGauge (icepeakMetricsDataSize      metrics) (realToFrac val) -- TODO: can be removed after dashboard has been updated to use icepeak_data_size_bytes
   setGauge (icepeakMetricsDataSizeBytes metrics) (realToFrac val)
 
 setJournalSize :: (MonadMonitor m, Real a) => a -> IcepeakMetrics -> m ()
@@ -67,7 +67,7 @@ setJournalSize val metrics = setGauge (icepeakMetricsJournalSize metrics) (realT
 -- Returns True, when it actually increased the counter and otherwise False.
 incrementDataWritten :: (MonadMonitor m, Real a) => a -> IcepeakMetrics -> m Bool
 incrementDataWritten num_bytes metrics = do
-  _ <- addCounter (icepeakMetricsDataWritten metrics) (realToFrac num_bytes) -- Ignore the result to silence linter
+  _ <- addCounter (icepeakMetricsDataWritten metrics) (realToFrac num_bytes) -- Ignore the result to silence linter. TODO: can be removed after dashboard has been updated to use icepeak_data_written_bytes_total
   addCounter (icepeakMetricsDataWrittenTotal metrics) (realToFrac num_bytes)
 
 -- | Increment the data written to the journal by the given number of bytes.


### PR DESCRIPTION
Pull request to fix #23. This PR:

- Expands the `IcepeakMetrics` data structure with two extra fields that follow the recommended Prometheus naming scheme.
- Changes the  `incrementDataWritten` and `setDataSize` to write to both the old and new metrics.
- Adds TODO comments indicating which lines can be removed later. The resulting lines are a bit long for my liking but that is all the more incentive to update the dashboard soon so that they can be removed :)

By adding the new metrics first, it'll become possible to update any dashboards (as mentioned in the linked issue) and then in a second PR the old metrics can be removed. I'm unsure what the best new name for the HTTP request counter metric would be. It could be something like `icepeak_http_requests_total`?

