### PR TITLE
Travis speed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,29 +26,43 @@ before_install:
 - export PATH=$HOME/.local/bin:$PATH
 - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
 
-install:
-  # Install the compiler. Pass --no-terminal to tell Stack it is not running in
-  # an interactive terminal, so it prints messages sequentially instead of
-  # updating them. The latter is less spammy but Travis does not support these
-  # interactive terminal capabilities.
-  - (cd server && stack setup -j2 --no-terminal)
-  - (cd client-haskell && stack setup -j2 --no-terminal)
-  - curl -o install-nix-2.3.1 https://nixos.org/releases/nix/nix-2.3.1/install
-  - sha256sum --check nix/nix_sha256sums
-  - sh ./install-nix-2.3.1 --no-daemon
-  - . $HOME/.nix-profile/etc/profile.d/nix.sh
-
 jobs:
   include:
-    - script:
-      # Build and test.
-      - (cd server && stack build -j2 --no-terminal)
-      - (cd server && stack test  -j2 --no-terminal)
-    - script:
-      - (cd client-haskell && stack build -j2 --no-terminal)
-      - (cd client-haskell && stack test  -j2 --no-terminal)
+    # Build and test jobs.
+    - name: Tests for server
+      cache:
+        directories:
+          - $HOME/.stack
+          - $TRAVIS_BUILD_DIR/server/.stack-work
+      script:
+        - (cd server && stack setup -j2 --no-terminal)
+        - (cd server && stack build -j2 --no-terminal)
+        - (cd server && stack test  -j2 --no-terminal)
+    - name: Tests for Haskell client
+      cache:
+        directories:
+          - $HOME/.stack
+          - $TRAVIS_BUILD_DIR/client-haskell/.stack-work
+      script:
+        - (cd client-haskell && stack setup -j2 --no-terminal)
+        - (cd client-haskell && stack build -j2 --no-terminal)
+        - (cd client-haskell && stack test  -j2 --no-terminal)
     # Check that the nix builds work
-    - script:
-      - nix-build --no-out-link -E '(import ./nix/nixpkgs.nix {}).haskellPackages.callPackage ./client-haskell/client.nix {}'
-    - script:
-      - nix-build --no-out-link ./server/default.nix
+    - name: Nix build of Haskell client
+      cache: disabled # no need to pull in .stack?
+      install:
+        - curl -o install-nix-2.3.1 https://nixos.org/releases/nix/nix-2.3.1/install
+        - sha256sum --check nix/nix_sha256sums
+        - sh ./install-nix-2.3.1 --no-daemon
+        - . $HOME/.nix-profile/etc/profile.d/nix.sh
+      script:
+        - nix-build --no-out-link -E '(import ./nix/nixpkgs.nix {}).haskellPackages.callPackage ./client-haskell/client.nix {}'
+    - name: Nix build of server
+      cache: disabled
+      install:
+        - curl -o install-nix-2.3.1 https://nixos.org/releases/nix/nix-2.3.1/install
+        - sha256sum --check nix/nix_sha256sums
+        - sh ./install-nix-2.3.1 --no-daemon
+        - . $HOME/.nix-profile/etc/profile.d/nix.sh
+      script:
+        - nix-build --no-out-link ./server/default.nix

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,6 @@ addons:
       # Haskell requires libgmp for big integers.
       - libgmp-dev
 
-cache:
-  directories:
-    - $HOME/.stack
-    - $TRAVIS_BUILD_DIR/server/.stack-work
-    - $TRAVIS_BUILD_DIR/client-haskell/.stack-work
-
 before_install:
 # Download and unpack the stack executable
 # We need the latest version to work around some bugs in older versions of stack

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ jobs:
         - (cd client-haskell && stack test  -j2 --no-terminal)
     # Check that the nix builds work
     - name: Nix build of Haskell client
-      cache: disabled # no need to pull in .stack?
+      cache: false # no need to pull in .stack here
       install:
         - curl -o install-nix-2.3.1 https://nixos.org/releases/nix/nix-2.3.1/install
         - sha256sum --check nix/nix_sha256sums
@@ -58,7 +58,7 @@ jobs:
       script:
         - nix-build --no-out-link -E '(import ./nix/nixpkgs.nix {}).haskellPackages.callPackage ./client-haskell/client.nix {}'
     - name: Nix build of server
-      cache: disabled
+      cache: false # no need to pull in .stack here
       install:
         - curl -o install-nix-2.3.1 https://nixos.org/releases/nix/nix-2.3.1/install
         - sha256sum --check nix/nix_sha256sums

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # Use a minimal base image.
-language: generic
+language: minimal
 
 # Do not spam us with build status emails please.
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,15 +40,15 @@ install:
 
 jobs:
   include:
-    script:
+    - script:
       # Build and test.
       - (cd server && stack build -j2 --no-terminal)
       - (cd server && stack test  -j2 --no-terminal)
-    script:
+    - script:
       - (cd client-haskell && stack build -j2 --no-terminal)
       - (cd client-haskell && stack test  -j2 --no-terminal)
     # Check that the nix builds work
-    script:
+    - script:
       - nix-build --no-out-link -E '(import ./nix/nixpkgs.nix {}).haskellPackages.callPackage ./client-haskell/client.nix {}'
-    script:
+    - script:
       - nix-build --no-out-link ./server/default.nix

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,15 +39,16 @@ install:
   - . $HOME/.nix-profile/etc/profile.d/nix.sh
 
 jobs:
-  script:
-    # Build and test.
-    - (cd server && stack build -j2 --no-terminal)
-    - (cd server && stack test  -j2 --no-terminal)
-  script:
-    - (cd client-haskell && stack build -j2 --no-terminal)
-    - (cd client-haskell && stack test  -j2 --no-terminal)
-  # Check that the nix builds work
-  script:
-    - nix-build --no-out-link -E '(import ./nix/nixpkgs.nix {}).haskellPackages.callPackage ./client-haskell/client.nix {}'
-  script:
-    - nix-build --no-out-link ./server/default.nix
+  include:
+    script:
+      # Build and test.
+      - (cd server && stack build -j2 --no-terminal)
+      - (cd server && stack test  -j2 --no-terminal)
+    script:
+      - (cd client-haskell && stack build -j2 --no-terminal)
+      - (cd client-haskell && stack test  -j2 --no-terminal)
+    # Check that the nix builds work
+    script:
+      - nix-build --no-out-link -E '(import ./nix/nixpkgs.nix {}).haskellPackages.callPackage ./client-haskell/client.nix {}'
+    script:
+      - nix-build --no-out-link ./server/default.nix

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,12 +38,16 @@ install:
   - sh ./install-nix-2.3.1 --no-daemon
   - . $HOME/.nix-profile/etc/profile.d/nix.sh
 
-script:
-  # Build and test.
-  - (cd server && stack build -j2 --no-terminal)
-  - (cd server && stack test  -j2 --no-terminal)
-  - (cd client-haskell && stack build -j2 --no-terminal)
-  - (cd client-haskell && stack test  -j2 --no-terminal)
+jobs:
+  script:
+    # Build and test.
+    - (cd server && stack build -j2 --no-terminal)
+    - (cd server && stack test  -j2 --no-terminal)
+  script:
+    - (cd client-haskell && stack build -j2 --no-terminal)
+    - (cd client-haskell && stack test  -j2 --no-terminal)
   # Check that the nix builds work
-  - nix-build --no-out-link -E '(import ./nix/nixpkgs.nix {}).haskellPackages.callPackage ./client-haskell/client.nix {}'
-  - nix-build --no-out-link ./server/default.nix
+  script:
+    - nix-build --no-out-link -E '(import ./nix/nixpkgs.nix {}).haskellPackages.callPackage ./client-haskell/client.nix {}'
+  script:
+    - nix-build --no-out-link ./server/default.nix

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # Use a minimal base image.
-language: c
+language: generic
 
 # Do not spam us with build status emails please.
 notifications:


### PR DESCRIPTION
I noticed when working on #65 that the travis CI system took quite long (16 minutes for my branch, between ~8 and ~30 minutes [in the build history on Travis](https://travis-ci.org/github/channable/icepeak/builds)). The Coronavirus also struck Almere, so I'm bored and decided to speed it up.

This PR:
- Splits the four tasks in the Travis CI file into their own job so that they can run in parallel. Travis allows parallel jobs even for open source projects.
- Optimizes the caching and setup for each of the resulting jobs. (Testing the server does not need the stack cache for the client and vice versa, for example)
- Changes the Travis base image from `c` to `minimal` ([link to docs](https://docs.travis-ci.com/user/languages/minimal-and-generic/)). This does not really matter too much for this project but is a little bit cleaner. It also meshes better with the pre-existing comment.

As a result, the wall clock time is now closer to five minutes. Be warned btw, every named job on Travis gets its own cache, which persists between builds. This means that the first time after this gets merged, performance will be horrible as everything is uncached. It'll get better afterwards though, see the attached screenshot.
![Screenshot from 2020-04-08 22-10-30](https://user-images.githubusercontent.com/2591792/78828951-ceaae780-79e5-11ea-9cbb-4607c14b71dd.png)
It could be sped up by a few more minutes if Travis had images with stack preinstalled, the cache contains so many files that even if nothing changed it takes >80 seconds to figure that out. Downloading the entire cache is not fast either. 