### PR TITLE
Update nixpkgs snapshot

### DIFF
--- a/client-haskell/default.nix
+++ b/client-haskell/default.nix
@@ -1,0 +1,14 @@
+{ # We expect getPkgs to be a lambda that gives us a package set. Example:
+  # the lambda in `nixpkgs/default.nix` without any arguments passed to it.
+  # That allows us to pass in config later, while allowing users to pass in
+  # their own version of Nixpkgs.
+  getPkgs ? import ../nix/nixpkgs.nix
+}:
+
+let
+  pkgs = getPkgs { };
+  icepeak-client = pkgs.haskellPackages.callPackage ./client.nix { };
+in
+  {
+    icepeak-client = icepeak-client;
+  }

--- a/client-haskell/src/Icepeak/Client.hs
+++ b/client-haskell/src/Icepeak/Client.hs
@@ -43,6 +43,7 @@ import Control.Retry (RetryPolicyM, recovering)
 import Data.Aeson (ToJSON)
 import Data.ByteString (ByteString)
 import Data.Foldable (toList)
+import Data.Semigroup ((<>))
 import Data.Text (Text)
 import Data.Word (Word16)
 

--- a/client-haskell/src/Icepeak/Client.hs
+++ b/client-haskell/src/Icepeak/Client.hs
@@ -43,7 +43,6 @@ import Control.Retry (RetryPolicyM, recovering)
 import Data.Aeson (ToJSON)
 import Data.ByteString (ByteString)
 import Data.Foldable (toList)
-import Data.Semigroup ((<>))
 import Data.Text (Text)
 import Data.Word (Word16)
 

--- a/client-haskell/stack.yaml
+++ b/client-haskell/stack.yaml
@@ -1,1 +1,14 @@
-resolver: lts-15.3
+resolver: lts-16.23
+
+# Note: This section will be ignored by stack, on non-NixOS systems.
+# It can be explicitly enabled on non-NixOS systems by passing --nix.
+# On NixOS this section is needed to bring the non-Haskell dependencies
+# into scope.
+nix:
+  add-gc-roots: true
+  packages:
+    - zlib
+    - libffi
+    - haskellPackages.libffi
+  path:
+    - "nixpkgs=../nix/nixpkgs.nix"

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,9 +1,9 @@
 let
-  rev = "5e329ff83c864cd0204118fc15c1ce5aed247c53";
+  rev = "a52850e30442aa0b058a7afa328679da4d38407f";
   extractedTarball = fetchTarball {
     url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
-    sha256 = "sha256:1jiyjs7c10d0gfgrgzlmhhsszp6sjr14l3rivc1j99hia8cnh8s4";
+    sha256 = "sha256:19frnv2pxcfi60gkal587xs9lpj4mjxxkcc26yvia9526yqg9k6l";
   };
 in
-  # extractedTarball will be a directory here, and 'import' will automatically append /default.nix here 
+  # extractedTarball will be a directory here, and 'import' will automatically append /default.nix here
   import extractedTarball

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -14,9 +14,9 @@ ghc-options:
 - -Wall
 
 dependencies:
-- aeson                             >= 1.4.6 && < 1.5
+- aeson                             >= 1.4.6 && < 1.6
 - async                             >= 2.2.2 && < 2.3
-- base                              >= 4.12.0 && < 4.14
+- base                              >= 4.12.0 && < 4.15
 - bytestring                        >= 0.10.8 && < 0.11
 - containers                        >= 0.6.0 && < 0.7
 - directory                         >= 1.3.3 && < 1.4
@@ -31,7 +31,7 @@ dependencies:
 - prometheus-metrics-ghc            >= 1.0.0 && < 1.1
 - random                            >= 1.1 && < 1.2
 - raven-haskell                     >= 0.1.2 && < 0.2
-- scotty                            >= 0.11.5 && < 0.12
+- scotty                            >= 0.11.5 && < 0.13
 - securemem                         >= 0.1.10 && < 0.2
 - sqlite-simple                     >= 0.4.16 && < 0.5
 - stm                               >= 2.5.0 && < 2.6
@@ -41,7 +41,7 @@ dependencies:
 - unordered-containers              >= 0.2.10 && < 0.3
 - uuid                              >= 1.3.13 && < 1.4
 - wai                               >= 3.2.2 && < 3.3
-- wai-extra                         >= 3.0.29 && < 3.1
+- wai-extra                         >= 3.0.29 && < 3.2
 - wai-middleware-prometheus         >= 1.0.0 && < 1.1
 - wai-websockets                    >= 3.0.1 && < 3.1
 - warp                              >= 3.3.0 && < 3.4

--- a/server/stack.yaml
+++ b/server/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-15.3
+resolver: lts-16.23
 
 extra-deps:
   - raven-haskell-0.1.2.1
@@ -6,6 +6,8 @@ extra-deps:
   - wai-middleware-prometheus-1.0.0
   - sqlite-simple-0.4.18.0
   - direct-sqlite-2.3.26
+  - scotty-0.12
+  - wai-extra-3.1.3
 
 # Reduce verbosity of stack output while compiling dependencies.
 build:
@@ -16,7 +18,10 @@ build:
 # On NixOS this section is needed to bring the non-Haskell dependencies
 # into scope.
 nix:
+  add-gc-roots: true
   packages:
     - zlib
+    - libffi
+    - haskellPackages.libffi
   path:
     - "nixpkgs=../nix/nixpkgs.nix"


### PR DESCRIPTION
This upgrades GHC from 8.8.2 to 8.8.4. This is necessary to stay compatible with the
master branch of nixpkgs. Icepeak was marked as broken there, since it
couldn't be built any more with the GHC and libraries available there.

Also update the Stack LTS release from 15.3 to 16.23.

This will then allows us to cut a 0.7.4 release, and get that included into nixpks to unbreak it.