### PR TITLE
Upgrade stack from LTS 16.23 to 17.2 (GHC 8.8 -> 8.10)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2020, Channable
+Copyright (c) 2021, Channable
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ Install with `stack install`.
 Integration tests are in `/server/integration-tests`.
 They are stand-alone scripts that can be executed directly, e.g. `./read_after_write_test.py`.
 
+### Running with the new low-latency garbage collector for GHC 8.10
+
+If you compiled icepeak with GHC 8.10 (or newer) then you can use the new low-latency
+garbage collector by passing the following runtime flags to icepeak:
+
+`icepeak +RTS -xn`
+
 ## Building the Haskell client library
 
 Cd into `/client-haskell`.

--- a/client-haskell/client.nix
+++ b/client-haskell/client.nix
@@ -4,6 +4,7 @@
 , bytestring
 , http-client
 , http-types
+, pkgs
 , text
 , retry
 , exceptions
@@ -39,5 +40,5 @@ mkDerivation {
       aeson base binary bytestring http-client http-types text retry exceptions
   ];
 
-  license = stdenv.lib.licenses.bsd3;
+  license = pkgs.lib.licenses.bsd3;
 }

--- a/client-haskell/stack.yaml
+++ b/client-haskell/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-16.23
+resolver: lts-17.2
 
 # Note: This section will be ignored by stack, on non-NixOS systems.
 # It can be explicitly enabled on non-NixOS systems by passing --nix.

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,8 +1,8 @@
 let
-  rev = "a52850e30442aa0b058a7afa328679da4d38407f";
+  rev = "bed08131cd29a85f19716d9351940bdc34834492";
   extractedTarball = fetchTarball {
     url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
-    sha256 = "sha256:19frnv2pxcfi60gkal587xs9lpj4mjxxkcc26yvia9526yqg9k6l";
+    sha256 = "sha256:19gxrzk9y4g2f09x2a4g5699ccw35h5frznn9n0pbsyv45n9vxix";
   };
 in
   # extractedTarball will be a directory here, and 'import' will automatically append /default.nix here

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -9,7 +9,7 @@ author: Channable
 maintainer: rkrzr
 description: Icepeak is a fast JSON document store with push notification support.
 synopsis: A fast JSON document store with push notification support.
-copyright: (c) 2020, Channable
+copyright: (c) 2021, Channable
 ghc-options:
 - -Wall
 

--- a/server/server.nix
+++ b/server/server.nix
@@ -15,6 +15,7 @@
 , mtl
 , network
 , optparse-applicative
+, pkgs
 , prometheus-client
 , prometheus-metrics-ghc
 , QuickCheck
@@ -142,5 +143,5 @@ mkDerivation {
     quickcheck-instances
   ];
 
-  license = stdenv.lib.licenses.bsd3;
+  license = pkgs.lib.licenses.bsd3;
 }

--- a/server/stack.yaml
+++ b/server/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-16.23
+resolver: lts-17.2
 
 extra-deps:
   - raven-haskell-0.1.2.1


### PR DESCRIPTION
This requires bumping the nixpkgs revision. The latest nixpkgs-unstable revision contains GHC 8.10.3, which we are now using. There were no breaking changes in any of our dependencies.