### PR TITLE
Add Vulnix as a nightly CI job

### DIFF
--- a/.semaphore/report-cronjob-failure.sh
+++ b/.semaphore/report-cronjob-failure.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Report the failure of a CI cronjob.
+# Requires $CRONJOB_HEALTHCHECK_URL to be set in the calling job.
+# See report-category-success.sh for an explanation of the flags.
+# The only difference between this file and the success script is the `/fail`
+# suffix to the URL.
+set -v
+
+curl \
+    --retry 3 \
+    --fail \
+    --silent \
+    --show-error \
+    --data "https://channable.semaphoreci.com/jobs/$SEMAPHORE_JOB_ID" \
+    "$CRONJOB_HEALTHCHECK_URL/fail"

--- a/.semaphore/report-cronjob-start.sh
+++ b/.semaphore/report-cronjob-start.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Report the start of a CI cronjob.
+# Requires $CRONJOB_HEALTHCHECK_URL to be set in the calling job.
+# See report-cronjob-success.sh for an explanation of the flags.
+# The only difference between this file and the success script is the `/start`
+# suffix to the URL and the guarantee of a successful exit.
+set -v
+
+curl \
+    --retry 3 \
+    --fail \
+    --silent \
+    --show-error \
+    --data "https://channable.semaphoreci.com/jobs/$SEMAPHORE_JOB_ID" \
+    "$CRONJOB_HEALTHCHECK_URL/start"
+
+# Make sure the exit code is "success" so we don't stop the pipeline should
+# the above fail.
+exit 0

--- a/.semaphore/report-cronjob-success.sh
+++ b/.semaphore/report-cronjob-success.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Report the success of a CI cronjob.
+# Requires $CRONJOB_HEALTHCHECK_URL to be set in the calling job.
+
+# Curl flags:
+#  - --retry: retry this many times on failure
+#  - --fail: fail on non-200 HTTP statuses
+#  - --silent: don't show progress bar or errors
+#  - --show-error: do show error messages
+#  - --data: Include this as HTTP POST body (shows up in the log)
+set -v
+
+curl \
+    --retry 3 \
+    --fail \
+    --silent \
+    --show-error \
+    --data "https://channable.semaphoreci.com/jobs/$SEMAPHORE_JOB_ID" \
+    "$CRONJOB_HEALTHCHECK_URL"

--- a/.semaphore/vulnix-nightly.yml
+++ b/.semaphore/vulnix-nightly.yml
@@ -1,0 +1,65 @@
+---
+version: "v1.0"
+name: "Icepeak CI Pipeline"
+
+agent:
+  machine:
+    type: "e1-standard-2"
+    os_image: "ubuntu2004"
+
+# global_job_config:
+  # TODO: create HC item
+  # env_vars:
+  #   - name: "CRONJOB_HEALTHCHECK_URL"
+  #     value: "https://hc-ping.com/39f74a9c-4dad-46ca-a200-d2cdee5b8533"
+
+blocks:
+  - name: "Run Vulnix"
+    dependencies: []
+
+    task:
+      prologue:
+        commands:
+          - "checkout"
+
+          # Download and verify Nix installation script.
+          - curl -o install-nix-2.3.15 https://releases.nixos.org/nix/nix-2.3.15/install
+          - sha256sum --check .semaphore/install-nix-2.3.15.sha256
+
+          # Restore `/nix` cache. Create the directory first, otherwise we encounter
+          # permission errors. We do this because the Semaphore cache is faster than
+          # both Cachix and cache.nixos.org.
+          # This cache should only contain Vulnix and its dependencies
+          - "sudo mkdir /nix"
+          - "sudo chown -R semaphore:semaphore /nix"
+          - "cache restore nix-store-"
+
+          # For some reason, Semaphore CI sets this variable, but it causes the nix installation to fail
+          - unset LD_LIBRARY_PATH
+
+          # Install Nix and source the shell configuration immediately.
+          - "sh ./install-nix-2.3.15 --no-daemon"
+          - ". $HOME/.nix-profile/etc/profile.d/nix.sh"
+
+      jobs:
+        - name: "Run Vulnix on the server build derivation"
+          commands:
+            - "nix-build --no-out-link ./server/default.nix"
+            - "cd server && nix-shell --run 'vulnix -w vulnix-ignorelist.toml $(nix path-info)'"
+
+      epilogue:
+        always:
+          commands:
+            # Store a copy of the nix store. This will be refreshed daily, which
+            # is more than sufficient for this repo.
+            - "cache store nix-store-$(date -u -Idate) /nix"
+
+        on_pass:
+          commands:
+            # Report success to Healthchecks.io
+            - ".semaphore/report-cronjob-success.sh"
+
+        on_fail:
+          commands:
+            # Report failure to Healthchecks.io
+            - ".semaphore/report-cronjob-failure.sh"

--- a/.semaphore/vulnix-nightly.yml
+++ b/.semaphore/vulnix-nightly.yml
@@ -7,11 +7,9 @@ agent:
     type: "e1-standard-2"
     os_image: "ubuntu2004"
 
-# global_job_config:
-  # TODO: create HC item
-  # env_vars:
-  #   - name: "CRONJOB_HEALTHCHECK_URL"
-  #     value: "https://hc-ping.com/39f74a9c-4dad-46ca-a200-d2cdee5b8533"
+global_job_config:
+  secrets:
+    - name: "icepeak-ci-nightly-healthcheck-url"
 
 blocks:
   - name: "Run Vulnix"
@@ -44,8 +42,9 @@ blocks:
       jobs:
         - name: "Run Vulnix on the server build derivation"
           commands:
+            - ".semaphore/report-cronjob-start.sh"
             - "nix-build --no-out-link ./server/default.nix"
-            - "cd server && nix-shell --run 'vulnix -w vulnix-ignorelist.toml $(nix path-info)'"
+            - "(cd server && nix-shell --run 'vulnix -w vulnix-ignorelist.toml $(nix path-info)')"
 
       epilogue:
         always:

--- a/server/shell.nix
+++ b/server/shell.nix
@@ -1,0 +1,16 @@
+{ # We expect getPkgs to be a lambda that gives us a package set. Example:
+  # the lambda in `nixpkgs/default.nix` without any arguments passed to it.
+  # That allows us to pass in config later, while allowing users to pass in
+  # their own version of Nixpkgs.
+  getPkgs ? import ../nix/nixpkgs.nix
+}:
+
+let
+  pkgs = getPkgs { };
+  vulnix = pkgs.vulnix;
+in
+  pkgs.mkShell {
+    buildInputs = [
+      vulnix
+    ];
+  }

--- a/server/vulnix-ignorelist.toml
+++ b/server/vulnix-ignorelist.toml
@@ -29,9 +29,10 @@ cve = ["CVE-2017-18589"]
 comment = "This CVE applies to the Rust cookie crate, not to the Haskell package with the same name"
 
 ["curl-7.74.0"]
-cve = ["CVE-2021-22897", "CVE-2021-22898", "CVE-2021-22901"]
+cve = ["CVE-2021-22897", "CVE-2021-22898", "CVE-2021-22901", "CVE-2021-22922", "CVE-2021-22926", "CVE-2021-22923", "CVE-2021-22925"]
 comment = """
-    These are fixed in curl 7.77, which has not ended up in nixpkgs yet.
+    CVE-2021-22897, CVE-2021-22898, CVE-2021-22901, CVE-2021-22922 are fixed in curl 7.77
+    CVE-2021-22926, CVE-2021-22923, CVE-2021-22925 are fixed in curl 7.78
     Curl is a dependency of raven-haskell.
 
     Recommended action: update raven-haskell
@@ -42,9 +43,10 @@ issue_url = "https://github.com/channable/icepeak/issues/70"
 cve = ["CVE-2019-6293"]
 comment = "This CVE describes a bug. As far as we know this library (a parser) is not called at runtime, which should prevent any issues"
 
-["glibc"]
+["glibc-2.32-35"]
 cve = ["CVE-2021-27645", "CVE-2021-33574", "CVE-2021-35942"]
-comment = "glibc is not a runtime dependency"
+comment = "These are fixed in 2.34"
+issue_url = "https://github.com/channable/icepeak/issues/73"
 
 ["http-client"]
 cve = ["CVE-2016-6287", "CVE-2020-11021"]
@@ -95,8 +97,8 @@ cve = ["CVE-2019-20633"]
 comment = "Package is not called at runtime"
 
 ["safe"]
-cve = ["CVE-2019-11644", "CVE-2021-33596"]
-comment = "Not applicable to Haskell package (but to F-Secure SAFE)"
+cve = ["CVE-2019-11644", "CVE-2021-33596", "CVE-2021-33594", "CVE-2021-33595"]
+comment = "Not applicable to the Haskell package"
 
 ["util-linux-2.36.1"]
 cve = ["CVE-2021-37600"]

--- a/server/vulnix-ignorelist.toml
+++ b/server/vulnix-ignorelist.toml
@@ -36,7 +36,7 @@ comment = """
 
     Recommended action: update raven-haskell
 """
-#issue_url = "TODO"
+issue_url = "https://github.com/channable/icepeak/issues/70"
 
 ["flex"]
 cve = ["CVE-2019-6293"]
@@ -66,7 +66,7 @@ comment = """
 
     Recommended action: verify if these CVE's are applicable
 """
-#issue_url = "TODO"
+issue_url = "https://github.com/channable/icepeak/issues/71"
 
 ["network"]
 cve = ["CVE-2021-35047", "CVE-2021-35048", "CVE-2021-35049", "CVE-2021-35050"]
@@ -88,7 +88,7 @@ comment = """
 
     Recommended action: update raven-haskell
 """
-#issue_url = "TODO"
+issue_url = "https://github.com/channable/icepeak/issues/70"
 
 ["patch-2.7.6"]
 cve = ["CVE-2019-20633"]

--- a/server/vulnix-ignorelist.toml
+++ b/server/vulnix-ignorelist.toml
@@ -16,10 +16,9 @@ cve = ["CVE-2019-18276"]
 comment = "This CVE applies only to Bash 5"
 # Note that Vulnix cannot handle wildcards (like bash-4.*)
 
-["binutils-2.35.1"]
+["binutils"]
 cve = ["CVE-2021-20284", "CVE-2021-20294", "CVE-2021-3487", "CVE-2020-35448"]
-comment = "These CVE's are fixed in binutils 2.36, which is not in nixpkgs yet"
-#issue_url = "TODO"
+comment = "binutils is not called at runtime"
 
 ["cereal"]
 cve = ["CVE-2020-11104", "CVE-2020-11105"]
@@ -31,22 +30,21 @@ comment = "This CVE applies to the Rust cookie crate, not to the Haskell package
 
 ["curl-7.74.0"]
 cve = ["CVE-2021-22897", "CVE-2021-22898", "CVE-2021-22901"]
-comment = "These are fixed in curl 7.77, which has not ended up in nixpkgs yet"
-#issue_url = "TODO"
+comment = """
+    These are fixed in curl 7.77, which has not ended up in nixpkgs yet.
+    Curl is a dependency of raven-haskell.
 
-["curl-7.76.1"]
-cve = ["CVE-2021-22897", "CVE-2021-22898", "CVE-2021-22901"]
-comment = "These are fixed in curl 7.77, which has not ended up in nixpkgs yet"
+    Recommended action: update raven-haskell
+"""
 #issue_url = "TODO"
 
 ["flex"]
 cve = ["CVE-2019-6293"]
 comment = "This CVE describes a bug. As far as we know this library (a parser) is not called at runtime, which should prevent any issues"
 
-["glibc-2.32-35"]
+["glibc"]
 cve = ["CVE-2021-27645", "CVE-2021-33574", "CVE-2021-35942"]
-comment = "fixed in 2.34, which is not yet available in nipxkgs"
-#issue_url = "TODO"
+comment = "glibc is not a runtime dependency"
 
 ["http-client"]
 cve = ["CVE-2016-6287", "CVE-2020-11021"]
@@ -58,15 +56,15 @@ comment = "CVE not applicable to the Haskell jwt package"
 
 ["libarchive-3.5.1"]
 cve = ["CVE-2021-36976"]
-comment = "Fix has not been released yet"
-#issue_url = "TODO"
+comment = "libarchive is not a runtime dependency"
 
 ["libxml2-2.9.10"]
 cve = ["CVE-2021-3517", "CVE-2021-3518", "CVE-2021-3537", "CVE-2021-3541"]
 comment = """
-    CVE's are fixed in 2.9.11. 2.9.12 is available in nixpkgs 21.05.
+    CVE's are fixed in 2.9.11.
+    libxml2 is a dependency of GHC and Raven, and might be used at runtime.
 
-    Recommended action: update to 2.9.12
+    Recommended action: verify if these CVE's are applicable
 """
 #issue_url = "TODO"
 
@@ -86,7 +84,9 @@ comment = """
 
     1.1.1k is in nixpkgs 20.09
 
-    Recommended action: update to 1.1.1k
+    This package is a dependency of raven-haskell
+
+    Recommended action: update raven-haskell
 """
 #issue_url = "TODO"
 

--- a/server/vulnix-ignorelist.toml
+++ b/server/vulnix-ignorelist.toml
@@ -1,0 +1,117 @@
+# When editing this file, keep to following guidelines:
+# - Keep the alphabetical order
+# - Only use package names without version when the CVE can NEVER apply to this repository
+#   (For example, when the CVE is for a Windows application with the same name)
+# - Otherwise, be specific about the package version
+# - Make a GitHub issue if a package needs to be updated, and link the issue (with `issue_url`)
+#
+# Useful resources:
+# Vulnix: https://github.com/flyingcircusio/vulnix
+# CVE details: https://nvd.nist.gov/vuln
+# You can find the details of a specific CVE like this:
+# https://nvd.nist.gov/vuln/detail/CVE-2021-12345
+
+["bash-4.4-p23"]
+cve = ["CVE-2019-18276"]
+comment = "This CVE applies only to Bash 5"
+# Note that Vulnix cannot handle wildcards (like bash-4.*)
+
+["binutils-2.35.1"]
+cve = ["CVE-2021-20284", "CVE-2021-20294", "CVE-2021-3487", "CVE-2020-35448"]
+comment = "These CVE's are fixed in binutils 2.36, which is not in nixpkgs yet"
+#issue_url = "TODO"
+
+["cereal"]
+cve = ["CVE-2020-11104", "CVE-2020-11105"]
+comment = "CVE's apply to C package, not to the Haskell package with the same name"
+
+["cookie"]
+cve = ["CVE-2017-18589"]
+comment = "This CVE applies to the Rust cookie crate, not to the Haskell package with the same name"
+
+["curl-7.74.0"]
+cve = ["CVE-2021-22897", "CVE-2021-22898", "CVE-2021-22901"]
+comment = "These are fixed in curl 7.77, which has not ended up in nixpkgs yet"
+#issue_url = "TODO"
+
+["curl-7.76.1"]
+cve = ["CVE-2021-22897", "CVE-2021-22898", "CVE-2021-22901"]
+comment = "These are fixed in curl 7.77, which has not ended up in nixpkgs yet"
+#issue_url = "TODO"
+
+["flex"]
+cve = ["CVE-2019-6293"]
+comment = "This CVE describes a bug. As far as we know this library (a parser) is not called at runtime, which should prevent any issues"
+
+["glibc-2.32-35"]
+cve = ["CVE-2021-27645", "CVE-2021-33574", "CVE-2021-35942"]
+comment = "fixed in 2.34, which is not yet available in nipxkgs"
+#issue_url = "TODO"
+
+["http-client"]
+cve = ["CVE-2016-6287", "CVE-2020-11021"]
+comment = "CVE's not applicable to the Haskell http-client package"
+
+["jwt"]
+cve = ["CVE-2016-7037"]
+comment = "CVE not applicable to the Haskell jwt package"
+
+["libarchive-3.5.1"]
+cve = ["CVE-2021-36976"]
+comment = "Fix has not been released yet"
+#issue_url = "TODO"
+
+["libxml2-2.9.10"]
+cve = ["CVE-2021-3517", "CVE-2021-3518", "CVE-2021-3537", "CVE-2021-3541"]
+comment = """
+    CVE's are fixed in 2.9.11. 2.9.12 is available in nixpkgs 21.05.
+
+    Recommended action: update to 2.9.12
+"""
+#issue_url = "TODO"
+
+["network"]
+cve = ["CVE-2021-35047", "CVE-2021-35048", "CVE-2021-35049", "CVE-2021-35050"]
+comment = "Not applicable to Haskell network package"
+
+["openssl"]
+cve = ["CVE-2016-7798", "CVE-2018-16395"]
+comment = "These are in the Ruby openssl library, not applicable here"
+
+["openssl-1.1.1i"]
+cve = ["CVE-2021-23840", "CVE-2021-23841", "CVE-2021-3449", "CVE-2021-3450"]
+comment = """
+    CVE-2021-23840, CVE-2021-23841: Fixed in 1.1.1j
+    CVE-2021-3450, CVE-2021-3449: Fixed in 1.1.1k
+
+    1.1.1k is in nixpkgs 20.09
+
+    Recommended action: update to 1.1.1k
+"""
+#issue_url = "TODO"
+
+["patch-2.7.6"]
+cve = ["CVE-2019-20633"]
+comment = "Package is not called at runtime"
+
+["safe"]
+cve = ["CVE-2019-11644", "CVE-2021-33596"]
+comment = "Not applicable to Haskell package (but to F-Secure SAFE)"
+
+["util-linux-2.36.1"]
+cve = ["CVE-2021-37600"]
+comment = "Package is not called at runtime"
+
+["vault"]
+cve = [
+    "CVE-2018-19786",
+    "CVE-2020-13223",
+    "CVE-2020-25594",
+    "CVE-2021-27400",
+    "CVE-2021-3024",
+]
+comment = "These are applicable to Hashicorp Vault, not to the Haskell package with the same name"
+
+["websockets"]
+cve = ["CVE-2021-33880"]
+comment = "Not applicable to Haskell websockets packages (but to the Python package with the same name)"


### PR DESCRIPTION
This PR is related to channable/devops/issues/3773

This PR adds a nightly run CI job that checks if there are no known CVE's in our dependencies, using Vulnix.
Vulnix is setup up to use a large ignorelist that makes sure that the CI does not start failing immediately.
There are issues created for the package updates we have to perform: #70 and #71, which are linked in the ignorelist to the right CVE's

I have tested the CI setup in a seperate branch. You can find the result here: https://channable.semaphoreci.com/workflows/d7ded8d6-be3e-4057-8054-1e05ab34a2b9?pipeline_id=333c929f-62b8-4d19-ae8b-9a0c22d52a6c
