### PR TITLE
Upgrade stack from LTS 17.2 to 18.18

### DIFF
--- a/client-haskell/default.nix
+++ b/client-haskell/default.nix
@@ -11,4 +11,5 @@ let
 in
   {
     icepeak-client = icepeak-client;
+    stack = pkgs.haskellPackages.stack;
   }

--- a/client-haskell/stack.yaml
+++ b/client-haskell/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-17.2
+resolver: lts-18.8
 
 # Note: This section will be ignored by stack, on non-NixOS systems.
 # It can be explicitly enabled on non-NixOS systems by passing --nix.

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,8 +1,8 @@
 let
-  rev = "bed08131cd29a85f19716d9351940bdc34834492";
+  rev = "d6a4500f88725c24b82f6f86fb3129ed0561800c";
   extractedTarball = fetchTarball {
     url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
-    sha256 = "sha256:19gxrzk9y4g2f09x2a4g5699ccw35h5frznn9n0pbsyv45n9vxix";
+    sha256 = "sha256:1xvgir3jr0mff9zk3ca2m0mzk6blyhjwmd5flyp3jp83bphr7301";
   };
 in
   # extractedTarball will be a directory here, and 'import' will automatically append /default.nix here

--- a/server/default.nix
+++ b/server/default.nix
@@ -11,4 +11,5 @@ let
 in
   {
     icepeak-server = icepeak-server;
+    stack = pkgs.haskellPackages.stack;
   }

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -26,10 +26,10 @@ dependencies:
 - monad-logger                      >= 0.3.31 && < 0.4
 - mtl                               >= 2.2.2 && < 2.3
 - network                           >= 2.8.0 && < 3.2
-- optparse-applicative              >= 0.14.0 && < 0.16
+- optparse-applicative              >= 0.15.0 && < 0.17
 - prometheus-client                 >= 1.0.0 && < 1.1
 - prometheus-metrics-ghc            >= 1.0.0 && < 1.1
-- random                            >= 1.1 && < 1.2
+- random                            >= 1.1 && < 1.3
 - raven-haskell                     >= 0.1.2 && < 0.2
 - scotty                            >= 0.11.5 && < 0.13
 - securemem                         >= 0.1.10 && < 0.2


### PR DESCRIPTION
This required bumping nixpkgs. No code changes were required.

We now include stack in the nix environment, so that we don't have
to depend on stack being installed externally.