### PR TITLE
Upgrade from LTS 18.18 to 19.17 and fix all breaking changes

### DIFF
--- a/client-haskell/stack.yaml
+++ b/client-haskell/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-18.8
+resolver: lts-19.17
 
 # Note: This section will be ignored by stack, on non-NixOS systems.
 # It can be explicitly enabled on non-NixOS systems by passing --nix.

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d6a4500f88725c24b82f6f86fb3129ed0561800c",
-        "sha256": "1xvgir3jr0mff9zk3ca2m0mzk6blyhjwmd5flyp3jp83bphr7301",
+        "rev": "80fc83ad314fe701766ee66ac8286307d65b39e3",
+        "sha256": "0axxkwpkxy2c45acm257l510p3kbc7vbfxlddz78q5bvvr5l70rc",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/d6a4500f88725c24b82f6f86fb3129ed0561800c.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/80fc83ad314fe701766ee66ac8286307d65b39e3.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/server/app/IcepeakTokenGen/Main.hs
+++ b/server/app/IcepeakTokenGen/Main.hs
@@ -13,7 +13,7 @@ import           AccessControl
 import           JwtAuth
 
 data Config = Config
-  { configJwtSecret      :: Maybe JWT.Signer
+  { configJwtSecret      :: Maybe JWT.EncodeSigner
   , configExpiresSeconds :: Maybe Integer
   , configWhitelist      :: [AuthPath]
   }

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -9,25 +9,25 @@ author: Channable
 maintainer: rkrzr
 description: Icepeak is a fast JSON document store with push notification support.
 synopsis: A fast JSON document store with push notification support.
-copyright: (c) 2021, Channable
+copyright: (c) 2022, Channable
 ghc-options:
 - -Wall
 
 dependencies:
-- aeson                             >= 1.4.6 && < 1.6
+- aeson                             >= 1.4.6 && < 2.1
 - async                             >= 2.2.2 && < 2.3
-- base                              >= 4.12.0 && < 4.15
+- base                              >= 4.12.0 && < 4.16
 - bytestring                        >= 0.10.8 && < 0.11
 - containers                        >= 0.6.0 && < 0.7
 - directory                         >= 1.3.3 && < 1.4
 - hashable                          >= 1.2.0 && < 1.4
 - http-types                        >= 0.12.3 && < 0.13
-- jwt                               >= 0.10.0 && < 0.11
+- jwt                               >= 0.10.0 && < 0.12
 - monad-logger                      >= 0.3.31 && < 0.4
 - mtl                               >= 2.2.2 && < 2.3
 - network                           >= 2.8.0 && < 3.2
 - optparse-applicative              >= 0.15.0 && < 0.17
-- prometheus-client                 >= 1.0.0 && < 1.1
+- prometheus-client                 >= 1.0.0 && < 1.2
 - prometheus-metrics-ghc            >= 1.0.0 && < 1.1
 - random                            >= 1.1 && < 1.3
 - raven-haskell                     >= 0.1.2 && < 0.2

--- a/server/src/Config.hs
+++ b/server/src/Config.hs
@@ -30,7 +30,7 @@ data Config = Config
   -- | The secret used for verifying the JWT signatures. If no secret is
   -- specified even though JWT authorization is enabled, tokens will still be
   -- used, but not be verified.
-  , configJwtSecret :: Maybe JWT.Signer
+  , configJwtSecret :: Maybe JWT.VerifySigner
   , configMetricsEndpoint :: Maybe MetricsConfig
   , configQueueCapacity :: Word
   , configSyncIntervalMicroSeconds :: Maybe Int
@@ -108,7 +108,9 @@ configParser environment = Config
     readFromEnvironment :: Read a => String -> Maybe a
     readFromEnvironment var = lookup var environment >>= Read.readMaybe
 
-    secretOption m = JWT.hmacSecret . Text.pack <$> strOption m
+    -- Note: We need a VerifySigner here (and not an EncodeSigner) since the Icepeak
+    -- server only verifies tokens
+    secretOption m = JWT.toVerify . JWT.hmacSecret . Text.pack <$> strOption m
 
 configInfo :: EnvironmentConfig -> ParserInfo Config
 configInfo environment = info parser description

--- a/server/src/JwtAuth.hs
+++ b/server/src/JwtAuth.hs
@@ -27,7 +27,7 @@ data VerificationError
   deriving (Show, Eq)
 
 -- | Check that a token is valid at the given time for the given secret.
-verifyToken :: POSIXTime -> JWT.Signer -> SBS.ByteString -> Either VerificationError (JWT VerifiedJWT)
+verifyToken :: POSIXTime -> JWT.VerifySigner -> SBS.ByteString -> Either VerificationError (JWT VerifiedJWT)
 verifyToken now secret = verifyNotBefore now
                        <=< verifyExpiry now
                        <=< verifySignature secret
@@ -54,7 +54,7 @@ verifyExpiry now token =
        else Right token
 
 -- | Verify that the token contains a valid signature.
-verifySignature :: JWT.Signer -> JWT UnverifiedJWT -> Either VerificationError (JWT VerifiedJWT)
+verifySignature :: JWT.VerifySigner -> JWT UnverifiedJWT -> Either VerificationError (JWT VerifiedJWT)
 verifySignature secret token =
  case JWT.verify secret token of
    Nothing     -> Left TokenSignatureInvalid
@@ -74,7 +74,7 @@ data TokenError
   deriving (Show, Eq)
 
 -- | Verify the token and extract the icepeak claim from it.
-extractClaim :: POSIXTime -> JWT.Signer -> SBS.ByteString -> Either TokenError IcepeakClaim
+extractClaim :: POSIXTime -> JWT.VerifySigner -> SBS.ByteString -> Either TokenError IcepeakClaim
 extractClaim now secret tokenBytes = do
   jwt <- first VerificationError $ verifyToken now secret tokenBytes
   claim <- first ClaimError $ getIcepeakClaim jwt

--- a/server/stack.yaml
+++ b/server/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-17.2
+resolver: lts-19.17
 
 extra-deps:
   - raven-haskell-0.1.2.1

--- a/server/stack.yaml
+++ b/server/stack.yaml
@@ -1,13 +1,7 @@
 resolver: lts-19.17
 
 extra-deps:
-  - raven-haskell-0.1.2.1
-  - prometheus-metrics-ghc-1.0.0
-  - wai-middleware-prometheus-1.0.0
-  - sqlite-simple-0.4.18.0
-  - direct-sqlite-2.3.26
-  - scotty-0.12
-  - wai-extra-3.1.3
+  - raven-haskell-0.1.4.1
 
 # Reduce verbosity of stack output while compiling dependencies.
 build:

--- a/server/tests/OrphanInstances.hs
+++ b/server/tests/OrphanInstances.hs
@@ -22,12 +22,3 @@ instance Arbitrary Modification where
     [ Put <$> arbitrary <*> arbitrary
     , Delete <$> arbitrary
     ]
-
-instance Arbitrary Value where
-  arbitrary = Gen.oneof
-    [ Object <$> Gen.scale (`div` 2) arbitrary
-    , Array  <$> Gen.scale (`div` 2) arbitrary
-    , String <$> arbitrary
-    , Bool   <$> arbitrary
-    , pure Null
-    ]

--- a/server/tests/StoreSpec.hs
+++ b/server/tests/StoreSpec.hs
@@ -7,7 +7,7 @@ import Test.Hspec (Spec, describe, it, shouldBe)
 import Test.Hspec.QuickCheck (prop)
 import Test.QuickCheck.Instances ()
 
-import qualified Data.HashMap.Strict as HashMap
+import qualified Data.Aeson.KeyMap as KeyMap
 
 import OrphanInstances ()
 import Store (Modification (..))
@@ -20,42 +20,42 @@ spec = do
     it "creates an object when putting 'x' into Null" $
       let
         before = Null
-        after = Object $ HashMap.singleton "x" (String "Robert")
+        after = Object $ KeyMap.singleton "x" (String "Robert")
       in
         Store.insert ["x"] (String "Robert") before `shouldBe` after
 
     it "overwrites a key when putting 'x' into {'x': ...}" $
       let
-        before = Object $ HashMap.singleton "x" (String "Arian")
-        after = Object $ HashMap.singleton "x" (String "Robert")
+        before = Object $ KeyMap.singleton "x" (String "Arian")
+        after = Object $ KeyMap.singleton "x" (String "Robert")
       in
         Store.insert ["x"] (String "Robert") before `shouldBe` after
 
     it "adds a key when putting 'x' into {'y': ...}" $
       let
-        before = Object $ HashMap.singleton "y" (String "Arian")
-        after = Object $ HashMap.fromList [("x", String "Robert"), ("y", String "Arian")]
+        before = Object $ KeyMap.singleton "y" (String "Arian")
+        after = Object $ KeyMap.fromList [("x", String "Robert"), ("y", String "Arian")]
       in
         Store.insert ["x"] (String "Robert") before `shouldBe` after
 
     it "creates a nested object when putting 'x/y' into Null" $
       let
         before = Null
-        after = Object $ HashMap.singleton "x" $ Object $ HashMap.singleton "y" "Stefan"
+        after = Object $ KeyMap.singleton "x" $ Object $ KeyMap.singleton "y" "Stefan"
       in
         Store.insert ["x", "y"] (String "Stefan") before `shouldBe` after
 
     it "updates a nested object when putting 'x/y' into {'x': {'y': ...}}" $
       let
-        before = Object $ HashMap.singleton "x" $ Object $ HashMap.singleton "y" "Radek"
-        after = Object $ HashMap.singleton "x" $ Object $ HashMap.singleton "y" "Stefan"
+        before = Object $ KeyMap.singleton "x" $ Object $ KeyMap.singleton "y" "Radek"
+        after = Object $ KeyMap.singleton "x" $ Object $ KeyMap.singleton "y" "Stefan"
       in
         Store.insert ["x", "y"] (String "Stefan") before `shouldBe` after
 
     it "adds a nested key when putting 'x/y' into {'x': {'y': ...}, 'z': ...}" $
       let
-        before = Object $ HashMap.fromList [("x", Object $ HashMap.singleton "y" "Nuno"), ("z", Null)]
-        after = Object $ HashMap.fromList [("x", Object $ HashMap.singleton "y" "Stefan"), ("z", Null)]
+        before = Object $ KeyMap.fromList [("x", Object $ KeyMap.singleton "y" "Nuno"), ("z", Null)]
+        after = Object $ KeyMap.fromList [("x", Object $ KeyMap.singleton "y" "Stefan"), ("z", Null)]
       in
         Store.insert ["x", "y"] (String "Stefan") before `shouldBe` after
 
@@ -83,23 +83,23 @@ spec = do
       let
         put = Put ["x"] (String "Robert")
         before = Null
-        after = Object $ HashMap.singleton "x" (String "Robert")
+        after = Object $ KeyMap.singleton "x" (String "Robert")
       in
         Store.applyModification put before `shouldBe` after
 
     it "overwrites a key when putting 'x' into {'x': ...}" $
       let
         put = Put ["x"] (String "Robert")
-        before = Object $ HashMap.singleton "x" (String "Arian")
-        after = Object $ HashMap.singleton "x" (String "Robert")
+        before = Object $ KeyMap.singleton "x" (String "Arian")
+        after = Object $ KeyMap.singleton "x" (String "Robert")
       in
         Store.applyModification put before `shouldBe` after
 
     it "adds a key when putting 'x' into {'y': ...}" $
       let
         put = Put ["x"] (String "Robert")
-        before = Object $ HashMap.singleton "y" (String "Arian")
-        after = Object $ HashMap.fromList [("x", String "Robert"), ("y", String "Arian")]
+        before = Object $ KeyMap.singleton "y" (String "Arian")
+        after = Object $ KeyMap.fromList [("x", String "Robert"), ("y", String "Arian")]
       in
         Store.applyModification put before `shouldBe` after
 
@@ -107,23 +107,23 @@ spec = do
       let
         put = Put ["x", "y"] (String "Stefan")
         before = Null
-        after = Object $ HashMap.singleton "x" $ Object $ HashMap.singleton "y" "Stefan"
+        after = Object $ KeyMap.singleton "x" $ Object $ KeyMap.singleton "y" "Stefan"
       in
         Store.applyModification put before `shouldBe` after
 
     it "updates a nested object when putting 'x/y' into {'x': {'y': ...}}" $
       let
         put = Put ["x", "y"] (String "Stefan")
-        before = Object $ HashMap.singleton "x" $ Object $ HashMap.singleton "y" "Radek"
-        after = Object $ HashMap.singleton "x" $ Object $ HashMap.singleton "y" "Stefan"
+        before = Object $ KeyMap.singleton "x" $ Object $ KeyMap.singleton "y" "Radek"
+        after = Object $ KeyMap.singleton "x" $ Object $ KeyMap.singleton "y" "Stefan"
       in
         Store.applyModification put before `shouldBe` after
 
     it "adds a nested key when putting 'x/y' into {'x': {'y': ...}, 'z': ...}" $
       let
         put = Put ["x", "y"] (String "Stefan")
-        before = Object $ HashMap.fromList [("x", Object $ HashMap.singleton "y" "Nuno"), ("z", Null)]
-        after = Object $ HashMap.fromList [("x", Object $ HashMap.singleton "y" "Stefan"), ("z", Null)]
+        before = Object $ KeyMap.fromList [("x", Object $ KeyMap.singleton "y" "Nuno"), ("z", Null)]
+        after = Object $ KeyMap.fromList [("x", Object $ KeyMap.singleton "y" "Stefan"), ("z", Null)]
       in
         Store.applyModification put before `shouldBe` after
 


### PR DESCRIPTION
This PR upgrades the stackage snapshot from 18.18 to 19.17.

This implies a GHC upgrade from 8.10 to 9.0.

There were breaking changes in two libraries:

- `Web.JWT` has split the Signer datatype into two versions: EncodeSigner and VerifySigner. The former is used to encode
newly minted tokens, while the latter is used to verify signed tokens.

- `Data.Aeson` has hidden the `HashMap` type behind a `KeyMap` type which only exposes `alterF` instead of `alter` and `adjust`. I added the last two functions to keep the rest of the code the same.

All the tests are passing again.