### PR TITLE
Add python dependencies in Nix configuration files for the server.

### DIFF
--- a/server/default.nix
+++ b/server/default.nix
@@ -1,1 +1,3 @@
+{}:
 (import ./icepeak-server.nix {}).icepeak-server-env
+

--- a/server/default.nix
+++ b/server/default.nix
@@ -1,15 +1,1 @@
-{ # We expect getPkgs to be a lambda that gives us a package set. Example:
-  # the lambda in `nixpkgs/default.nix` without any arguments passed to it.
-  # That allows us to pass in config later, while allowing users to pass in
-  # their own version of Nixpkgs.
-  getPkgs ? import ../nix/nixpkgs.nix
-}:
-
-let
-  pkgs = getPkgs { };
-  icepeak-server = pkgs.haskellPackages.callPackage ./server.nix { };
-in
-  {
-    icepeak-server = icepeak-server;
-    stack = pkgs.haskellPackages.stack;
-  }
+(import ./icepeak-server.nix {}).icepeak-server-env

--- a/server/icepeak-server.nix
+++ b/server/icepeak-server.nix
@@ -1,0 +1,28 @@
+{ # We expect getPkgs to be a lambda that gives us a package set. Example:
+  # the lambda in `nixpkgs/default.nix` without any arguments passed to it.
+  # That allows us to pass in config later, while allowing users to pass in
+  # their own version of Nixpkgs.
+  getPkgs ? import ../nix/nixpkgs.nix
+}:
+
+let
+  pkgs = getPkgs { };
+  python = pkgs.python310;
+  pythonEnv = python.withPackages (p: [
+    p.websockets
+    p.requests
+  ]);
+  libs = with pkgs; [ ];
+in
+  rec {
+    icepeak-server = pkgs.haskellPackages.callPackage ./server.nix { };
+    stack = pkgs.haskellPackages.stack;
+    icepeak-server-env = pkgs.buildEnv {
+      name = "icepeak-server-env";
+      paths = [
+        stack
+        icepeak-server
+        pythonEnv
+      ] ++ libs;
+    };
+  }

--- a/server/icepeak-server.nix
+++ b/server/icepeak-server.nix
@@ -24,5 +24,6 @@ in
         icepeak-server
         pythonEnv
       ] ++ libs;
+      passthru = { icepeak-server = icepeak-server; stack = stack; };
     };
   }

--- a/server/integration-tests/multiple_clients_test.py
+++ b/server/integration-tests/multiple_clients_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.7
+#!/usr/bin/env python3
 """
 This test creates 10 websocket connections, then PUTs some new data, and then tests that all 10 clients
 received the same data.


### PR DESCRIPTION
Related to issue https://github.com/channable/icepeak/issues/87. 
I added the python dependencies needed for the integration tests, but didn't add GMP to the list since Icepeak builds successfully using `stack build --nix`.