### PR TITLE
Enable log toggling for Sync operations.

### DIFF
--- a/server/src/Config.hs
+++ b/server/src/Config.hs
@@ -43,6 +43,8 @@ data Config = Config
   -- Just indicates that a key is given.
   , configSentryDSN :: Maybe String
   , configStorageBackend :: StorageBackend
+  -- | Enable logging of Sync duration
+  , configSyncLogging :: Bool
   }
 
 data MetricsConfig = MetricsConfig
@@ -101,6 +103,8 @@ configParser environment = Config
               environ "SENTRY_DSN" <>
               help "Sentry DSN used for Sentry logging, defaults to the value of the SENTRY_DSN environment variable if present. If no secret is passed, Sentry logging will be disabled."))
   <*> storageBackend
+  <*> switch (long "sync-log" <>
+             help "Enable logging the duration of Sync operations.")
 
   where
     environ var = foldMap value (lookup var environment)

--- a/server/src/Core.hs
+++ b/server/src/Core.hs
@@ -94,6 +94,7 @@ newCore config logger metrics = do
     , pcJournalFile = journalFile
     , pcLogger = logger
     , pcMetrics = metrics
+    , pcLogSync = configSyncLogging config
     }
   for eitherValue $ \value -> do
     -- create synchronization channels

--- a/server/src/Persistence.hs
+++ b/server/src/Persistence.hs
@@ -56,6 +56,7 @@ data PersistenceConfig = PersistenceConfig
   , pcJournalFile :: Maybe FilePath
   , pcLogger      :: Logger
   , pcMetrics     :: Maybe Metrics.IcepeakMetrics
+  , pcLogSync     :: Bool
   }
 
 -- | Get the actual value
@@ -161,7 +162,9 @@ syncToBackend File pv = do
     syncFile pv
     end <- Clock.getTime Clock.Monotonic
     let time = Clock.toNanoSecs (Clock.diffTimeSpec end start) `div` 1000000
-    logMessage pv $ Text.concat ["It took ", Text.pack $ show time, " ms to synchronize Icepeak on disk."]
+    if pcLogSync $ pvConfig pv then
+      logMessage pv $ Text.concat ["It took ", Text.pack $ show time, " ms to synchronize Icepeak on disk."]
+    else return ()
 syncToBackend Sqlite pv = syncSqliteFile pv
 
 -- * SQLite loading and syncing


### PR DESCRIPTION
Before releasing, so not to break past behaviour, I preferred to add toggling for the Sync operation log.