### PR TITLE
Add logging on duration of journaling operations

### DIFF
--- a/server/src/Persistence.hs
+++ b/server/src/Persistence.hs
@@ -51,7 +51,7 @@ data PersistentValue = PersistentValue
     -- ^ flag indicating whether the current value of 'pvValue' has not yet been persisted to disk
   , pvJournal      :: Maybe Handle
   , pvJournalStats :: TVar JournalStatistics
-    -- ^ Structure keeping track of the duration of journaling operations
+    -- ^ Structure keeping track of the duration of journaling operations.
   }
 
 data JournalStatistics = JournalStatistics


### PR DESCRIPTION
Fixes https://github.com/channable/icepeak/issues/94: I added support for logging of the duration of logging operations, including average, minimum and maximum, over the time frame between two Sync operations.