### PR TITLE
Add metrics on WebSocket queue

### DIFF
--- a/server/src/Core.hs
+++ b/server/src/Core.hs
@@ -23,7 +23,7 @@ import Control.Concurrent.MVar (MVar, newMVar, putMVar)
 import Control.Concurrent.STM (atomically)
 import Control.Concurrent.STM.TBQueue (TBQueue, newTBQueueIO, readTBQueue, writeTBQueue, isFullTBQueue)
 import Control.Concurrent.STM.TVar (TVar, newTVarIO)
-import Control.Monad (forever, unless, replicateM_, when)
+import Control.Monad (forever, unless, when)
 import Control.Monad.IO.Class
 import Data.Aeson (Value (..))
 import Data.Foldable (forM_, for_)
@@ -110,7 +110,8 @@ postQuit core = do
   atomically $ do
     writeTBQueue (coreQueue core) Stop
     writeTBQueue (coreUpdates core) Nothing
-  replicateM_ 2 $ for_ (coreMetrics core) Metrics.incrementQueueAdded
+  for_ (coreMetrics core) Metrics.incrementQueueAdded
+  for_ (coreMetrics core) Metrics.incrementWsQueueAdded
 
 -- | Try to enqueue a command. It succeeds if the queue is not full, otherwise,
 -- nothing is changed. This should be used for non-critical commands that can
@@ -169,14 +170,15 @@ runCommandLoop core = go
 
 -- | Post an update to the core's update queue (read by the websocket subscribers)
 postUpdate :: Path -> Core -> IO ()
-postUpdate path core = atomically $ do
-  value <- Persistence.getValue (coreCurrentValue core)
-  full <- isFullTBQueue (coreUpdates core)
-  -- In order not to block the reader thread, and subsequently stop processing coreQueue,
-  -- we don't send new updates to subscribers if coreUpdates is full.
-  if full then
-    return ()
-    else writeTBQueue (coreUpdates core) (Just $ Updated path value)
+postUpdate path core = do
+  isWsQueueFull <- atomically $ do
+    value <- Persistence.getValue (coreCurrentValue core)
+    full <- isFullTBQueue (coreUpdates core)
+    -- In order not to block the reader thread, and subsequently stop processing coreQueue,
+    -- we don't send new updates to subscribers if coreUpdates is full.
+    when (not full) $ writeTBQueue (coreUpdates core) (Just $ Updated path value)
+    return full
+  when (not isWsQueueFull) $ for_ (coreMetrics core) Metrics.incrementWsQueueAdded
 
 -- | Periodically send a 'Sync' command to the 'Core' if enabled in the core
 -- configuration.

--- a/server/src/Core.hs
+++ b/server/src/Core.hs
@@ -110,8 +110,9 @@ postQuit core = do
   atomically $ do
     writeTBQueue (coreQueue core) Stop
     writeTBQueue (coreUpdates core) Nothing
-  for_ (coreMetrics core) Metrics.incrementQueueAdded
-  for_ (coreMetrics core) Metrics.incrementWsQueueAdded
+  for_ (coreMetrics core) $ \metrics -> do
+    Metrics.incrementQueueAdded metrics
+    Metrics.incrementWsQueueAdded metrics
 
 -- | Try to enqueue a command. It succeeds if the queue is not full, otherwise,
 -- nothing is changed. This should be used for non-critical commands that can

--- a/server/src/Metrics.hs
+++ b/server/src/Metrics.hs
@@ -33,6 +33,7 @@ data IcepeakMetrics = IcepeakMetrics
   , icepeakMetricsSyncDuration      :: Histogram
   , icepeakMetricsWsQueueAdded      :: Counter
   , icepeakMetricsWsQueueRemoved    :: Counter
+  , icepeakMetricsWsSkippedUpdates  :: Counter
   }
 
 createAndRegisterIcepeakMetrics :: IO IcepeakMetrics
@@ -53,13 +54,15 @@ createAndRegisterIcepeakMetrics = IcepeakMetrics
   <*> register (counter (Info "icepeak_internal_queue_items_added"
                               "Total number of items added to the queue."))
   <*> register (counter (Info "icepeak_internal_queue_items_removed"
-                              "Total number of items removed from the queue.."))
+                              "Total number of items removed from the queue."))
   <*> register (histogram (Info "icepeak_sync_duration" "Duration of a Sync command.")
                           syncBuckets)
   <*> register (counter (Info "icepeak_internal_ws_queue_items_added"
                               "Total number of items added to the WebSocket queue."))
   <*> register (counter (Info "icepeak_internal_ws_queue_items_removed"
-                              "Total number of items removed from the WebSocket queue.."))
+                              "Total number of items removed from the WebSocket queue."))
+  <*> register (counter (Info "icepeak_internal_ws_skipped_updates_total"
+                              "Total number of updates that have not been sent to subscribers."))
   where
     requestHistogram = histogram (Info "http_request_duration_seconds"
                                      "Duration of HTTP requests since starting Icepeak.")
@@ -118,3 +121,6 @@ incrementWsQueueAdded = incCounter . icepeakMetricsWsQueueAdded
 
 incrementWsQueueRemoved :: MonadMonitor m => IcepeakMetrics -> m ()
 incrementWsQueueRemoved = incCounter . icepeakMetricsWsQueueRemoved
+
+incrementWsSkippedUpdates :: MonadMonitor m => IcepeakMetrics -> m ()
+incrementWsSkippedUpdates = incCounter . icepeakMetricsWsSkippedUpdates

--- a/server/src/Metrics.hs
+++ b/server/src/Metrics.hs
@@ -31,6 +31,8 @@ data IcepeakMetrics = IcepeakMetrics
   , icepeakMetricsQueueAdded        :: Counter
   , icepeakMetricsQueueRemoved      :: Counter
   , icepeakMetricsSyncDuration      :: Histogram
+  , icepeakMetricsWsQueueAdded      :: Counter
+  , icepeakMetricsWsQueueRemoved    :: Counter
   }
 
 createAndRegisterIcepeakMetrics :: IO IcepeakMetrics
@@ -54,6 +56,10 @@ createAndRegisterIcepeakMetrics = IcepeakMetrics
                               "Total number of items removed from the queue.."))
   <*> register (histogram (Info "icepeak_sync_duration" "Duration of a Sync command.")
                           syncBuckets)
+  <*> register (counter (Info "icepeak_internal_ws_queue_items_added"
+                              "Total number of items added to the WebSocket queue."))
+  <*> register (counter (Info "icepeak_internal_ws_queue_items_removed"
+                              "Total number of items removed from the WebSocket queue.."))
   where
     requestHistogram = histogram (Info "http_request_duration_seconds"
                                      "Duration of HTTP requests since starting Icepeak.")
@@ -106,3 +112,9 @@ incrementQueueRemoved = incCounter . icepeakMetricsQueueRemoved
 
 measureSyncDuration :: (MonadIO m, MonadMonitor m) => IcepeakMetrics -> m a -> m a
 measureSyncDuration = observeDuration . icepeakMetricsSyncDuration
+
+incrementWsQueueAdded :: MonadMonitor m => IcepeakMetrics -> m ()
+incrementWsQueueAdded = incCounter . icepeakMetricsWsQueueAdded
+
+incrementWsQueueRemoved :: MonadMonitor m => IcepeakMetrics -> m ()
+incrementWsQueueRemoved = incCounter . icepeakMetricsWsQueueRemoved

--- a/server/src/WebsocketServer.hs
+++ b/server/src/WebsocketServer.hs
@@ -12,6 +12,7 @@ import Control.Concurrent.STM.TBQueue (readTBQueue)
 import Control.Exception (SomeAsyncException, SomeException, finally, fromException, catch, throwIO)
 import Control.Monad (forever)
 import Data.Aeson (Value)
+import Data.Foldable (for_)
 import Data.Text (Text)
 import Data.UUID
 import System.Random (randomIO)
@@ -135,6 +136,7 @@ processUpdates core = go
   where
     go = do
       maybeUpdate <- atomically $ readTBQueue (coreUpdates core)
+      for_ (coreMetrics core) Metrics.incrementWsQueueRemoved
       case maybeUpdate of
         Just (Updated path value) -> do
           clients <- readMVar (coreClients core)


### PR DESCRIPTION
We wanted to observe how this queue grows and shrinks over time. The metrics are available on the Prometheus endpoint.