### PR TITLE
Change threading model for subscribers

### DIFF
--- a/server/src/Config.hs
+++ b/server/src/Config.hs
@@ -45,6 +45,8 @@ data Config = Config
   , configStorageBackend :: StorageBackend
   -- | Enable logging of Sync duration
   , configSyncLogging :: Bool
+  -- | Delay between two pings to the client (useful in order to keep the connexion alive)
+  , configWebSocketPingInterval:: Int
   }
 
 data MetricsConfig = MetricsConfig
@@ -105,6 +107,11 @@ configParser environment = Config
   <*> storageBackend
   <*> switch (long "sync-log" <>
              help "Enable logging the duration of Sync operations.")
+  <*> option auto
+       (long "websocket-ping-interval" <>
+        metavar "WS-PING-INTERVAL" <>
+        value 30 <>
+        help "The interval of time (in seconds) between two pings to the WebSocket clients. It is instrumental in keeping connections alive.")
 
   where
     environ var = foldMap value (lookup var environment)

--- a/server/src/Subscription.hs
+++ b/server/src/Subscription.hs
@@ -21,7 +21,6 @@ import Data.Hashable (Hashable)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 
-import qualified Control.Concurrent.Async as Async
 import qualified Data.HashMap.Strict as HashMap
 import qualified Data.Text as Text
 
@@ -77,18 +76,16 @@ unsubscribe path subid (SubscriptionTree here inner) =
 
 -- Invoke f for all subscribers to the path. The subscribers get passed the
 -- subvalue at the path that they are subscribed to.
-broadcast :: (conn -> Value -> IO ()) -> [Text] -> Value -> SubscriptionTree id conn -> IO ()
-broadcast f path value tree =
-  -- We broadcast concurrently since all updates are independent of each other
-  Async.mapConcurrently_ (uncurry f) notifications
+broadcast :: (state -> Value -> IO ()) -> [Text] -> Value -> SubscriptionTree id state -> IO ()
+broadcast f path value tree = mapM_ (uncurry f) notifications
   where notifications = broadcast' path value tree
 
 -- Like broadcast, but return a list of notifications rather than invoking an
 -- effect on each of them.
-broadcast' :: [Text] -> Value -> SubscriptionTree id conn -> [(conn, Value)]
+broadcast' :: [Text] -> Value -> SubscriptionTree id state -> [(state, Value)]
 broadcast' = \path value tree -> execWriter $ loop path value tree
   where
-  loop :: [Text] -> Value -> SubscriptionTree id conn -> Writer [(conn, Value)] ()
+  loop :: [Text] -> Value -> SubscriptionTree id state -> Writer [(state, Value)] ()
   loop path value (SubscriptionTree here inner) = do
     case path of
       [] -> do
@@ -110,11 +107,11 @@ showTree tree =
     withPrefix prefix (SubscriptionTree here inner) =
       let
         strHere :: String
-        strHere = concatMap (\cid -> " * " <> (show cid) <> "\n") (HashMap.keys here)
+        strHere = concatMap (\cid -> " * " <> show cid <> "\n") (HashMap.keys here)
         showInner iPrefix t = iPrefix <> "\n" <> withPrefix iPrefix t
         strInner :: String
         strInner = concat $ HashMap.mapWithKey (\key -> showInner (prefix <> "/" <> Text.unpack key)) inner
       in
         strHere <> strInner
   in
-    "/\n" <> (withPrefix "" tree)
+    "/\n" <> withPrefix "" tree

--- a/server/tests/JwtSpec.hs
+++ b/server/tests/JwtSpec.hs
@@ -13,6 +13,7 @@ import qualified Data.Text.Encoding as Text
 import JwtAuth
 import AccessControl
 import OrphanInstances ()
+import Data.Maybe (fromJust)
 
 spec :: Spec
 spec = do
@@ -54,13 +55,13 @@ spec = do
       extractClaim now verifySigner token `shouldBe` Right testAccess
 
     it "should reject an expired token" $ do
-      let Just expDate = JWT.numericDate $ now - 10
+      let expDate = fromJust $ JWT.numericDate $ now - 10
           claims = testClaims { JWT.exp = Just expDate }
           expiredToken = Text.encodeUtf8 $ JWT.encodeSigned testSecret joseHeader claims
       extractClaim now verifySigner expiredToken `shouldBe` Left (VerificationError TokenExpired)
 
     it "should reject a token before its 'not before' date" $ do
-      let Just nbfDate = JWT.numericDate $ now + 10
+      let nbfDate = fromJust $ JWT.numericDate $ now + 10
           claims = testClaims { JWT.nbf = Just nbfDate }
           nbfToken = Text.encodeUtf8 $ JWT.encodeSigned testSecret joseHeader claims
       extractClaim now verifySigner nbfToken `shouldBe` Left (VerificationError TokenUsedTooEarly)

--- a/server/tests/OrphanInstances.hs
+++ b/server/tests/OrphanInstances.hs
@@ -1,6 +1,5 @@
 module OrphanInstances where
 
-import Data.Aeson (Value (..))
 import Test.QuickCheck.Instances ()
 import Test.QuickCheck.Arbitrary (Arbitrary (..))
 import qualified Test.QuickCheck.Gen as Gen


### PR DESCRIPTION
The previous model for subscribers was monolithic: one thread was managing all the subscribers, and if one of them failed to answer, it could block the entire subscribers mechanism. We want to avoid this "single point of failure" kind of architecture, so we opted for a different thread model.

Now, for *each* subscriber, we have a dedicated thread that handles sending the updates to them. This thread is killed on timeout or unsubscribing. Icepeak's main thread feeds these threads through dedicated bounded queues (one per subscriber).

This PR starts as a draft because I want https://github.com/channable/icepeak/pull/100 merged first.