### PR TITLE
Increase WebSocket skipped updates metric when queue is not fetched

### DIFF
--- a/server/src/Core.hs
+++ b/server/src/Core.hs
@@ -198,7 +198,7 @@ postUpdate path core = do
     return full
   for_ (coreMetrics core) $
     if isWsQueueFull
-    then Metrics.incrementWsSkippedUpdates
+    then Metrics.incrementWsQueueSkippedUpdates
     else Metrics.incrementWsQueueAdded
 
 -- | Periodically send a 'Sync' command to the 'Core' if enabled in the core

--- a/server/src/Metrics.hs
+++ b/server/src/Metrics.hs
@@ -19,21 +19,22 @@ type HttpStatusCode = Text
 type HttpRequestHistogram = Vector (HttpMethodLabel, HttpStatusCode) Histogram
 
 data IcepeakMetrics = IcepeakMetrics
-  { icepeakMetricsRequestCounter    :: HttpRequestHistogram
+  { icepeakMetricsRequestCounter        :: HttpRequestHistogram
   -- TODO: the following line can be removed after dashboard has been updated to use icepeak_data_size_bytes
-  , icepeakMetricsDataSize          :: Gauge
-  , icepeakMetricsDataSizeBytes     :: Gauge
-  , icepeakMetricsJournalSize       :: Gauge
-  , icepeakMetricsDataWritten       :: Counter
-  , icepeakMetricsDataWrittenTotal  :: Counter
-  , icepeakMetricsJournalWritten    :: Counter
-  , icepeakMetricsSubscriberCount   :: Gauge
-  , icepeakMetricsQueueAdded        :: Counter
-  , icepeakMetricsQueueRemoved      :: Counter
-  , icepeakMetricsSyncDuration      :: Histogram
-  , icepeakMetricsWsQueueAdded      :: Counter
-  , icepeakMetricsWsQueueRemoved    :: Counter
-  , icepeakMetricsWsSkippedUpdates  :: Counter
+  , icepeakMetricsDataSize              :: Gauge
+  , icepeakMetricsDataSizeBytes         :: Gauge
+  , icepeakMetricsJournalSize           :: Gauge
+  , icepeakMetricsDataWritten           :: Counter
+  , icepeakMetricsDataWrittenTotal      :: Counter
+  , icepeakMetricsJournalWritten        :: Counter
+  , icepeakMetricsSubscriberCount       :: Gauge
+  , icepeakMetricsQueueAdded            :: Counter
+  , icepeakMetricsQueueRemoved          :: Counter
+  , icepeakMetricsSyncDuration          :: Histogram
+  , icepeakMetricsWsQueueAdded          :: Counter
+  , icepeakMetricsWsQueueRemoved        :: Counter
+  , icepeakMetricsWsQueueSkippedUpdates :: Counter
+  , icepeakMetricsWsSkippedUpdates      :: Counter
   }
 
 createAndRegisterIcepeakMetrics :: IO IcepeakMetrics
@@ -61,7 +62,9 @@ createAndRegisterIcepeakMetrics = IcepeakMetrics
                               "Total number of items added to the WebSocket queue."))
   <*> register (counter (Info "icepeak_internal_ws_queue_items_removed"
                               "Total number of items removed from the WebSocket queue."))
-  <*> register (counter (Info "icepeak_internal_ws_skipped_updates_total"
+  <*> register (counter (Info "icepeak_internal_ws_queue_skipped_updates"
+                              "Total number of updates discarded from the WebSocket queue."))
+  <*> register (counter (Info "icepeak_subscribers_skipped_updates_total"
                               "Total number of updates that have not been sent to subscribers."))
   where
     requestHistogram = histogram (Info "http_request_duration_seconds"
@@ -70,7 +73,7 @@ createAndRegisterIcepeakMetrics = IcepeakMetrics
     syncBuckets      = exponentialBuckets 0.001 2 12
 
 countHttpRequest :: IcepeakMetrics -> Http.Method -> Http.Status -> TimeSpec -> TimeSpec -> IO ()
-countHttpRequest metrics method status start end = withLabel (icepeakMetricsRequestCounter metrics) label (flip observe latency)
+countHttpRequest metrics method status start end = withLabel (icepeakMetricsRequestCounter metrics) label (`observe` latency)
   where
     label = (textMethod, textStatus)
     textMethod = decodeUtf8 method
@@ -121,6 +124,9 @@ incrementWsQueueAdded = incCounter . icepeakMetricsWsQueueAdded
 
 incrementWsQueueRemoved :: MonadMonitor m => IcepeakMetrics -> m ()
 incrementWsQueueRemoved = incCounter . icepeakMetricsWsQueueRemoved
+
+incrementWsQueueSkippedUpdates :: MonadMonitor m => IcepeakMetrics -> m ()
+incrementWsQueueSkippedUpdates = incCounter . icepeakMetricsWsQueueSkippedUpdates
 
 incrementWsSkippedUpdates :: MonadMonitor m => IcepeakMetrics -> m ()
 incrementWsSkippedUpdates = incCounter . icepeakMetricsWsSkippedUpdates


### PR DESCRIPTION
Fixes https://github.com/channable/icepeak/issues/103.

I reused the already existing metric, because the user-facing issue would be the same, and we can easily know in which case we are looking at the size of the queue (which can be computed from other metrics).