### PR TITLE
Prefix all server modules with Icepeak.Server

### DIFF
--- a/server/app/Icepeak/Main.hs
+++ b/server/app/Icepeak/Main.hs
@@ -15,18 +15,18 @@ import qualified Prometheus
 import qualified Prometheus.Metric.GHC
 import qualified System.Posix.Signals as Signals
 
-import Config (Config (..), configInfo)
-import Core (Core (..))
-import Persistence (getDataFile, setupStorageBackend)
-import Logger (Logger, LogLevel(..), postLog)
+import Icepeak.Server.Config (Config (..), configInfo)
+import Icepeak.Server.Core (Core (..))
+import Icepeak.Server.Persistence (getDataFile, setupStorageBackend)
+import Icepeak.Server.Logger (Logger, LogLevel(..), postLog)
 
-import qualified Core
-import qualified HttpServer
-import qualified Server
-import qualified WebsocketServer
-import qualified Logger
-import qualified Metrics
-import qualified MetricsServer
+import qualified Icepeak.Server.Core as Core
+import qualified Icepeak.Server.HttpServer as HttpServer
+import qualified Icepeak.Server.Server as Server
+import qualified Icepeak.Server.WebsocketServer as WebsocketServer
+import qualified Icepeak.Server.Logger as Logger
+import qualified Icepeak.Server.Metrics as Metrics
+import qualified Icepeak.Server.MetricsServer as MetricsServer
 
 -- Install SIGTERM and SIGINT handlers to do a graceful exit.
 installHandlers :: Core -> IO ()

--- a/server/app/IcepeakTokenGen/Main.hs
+++ b/server/app/IcepeakTokenGen/Main.hs
@@ -8,8 +8,8 @@ import           System.Environment  (getEnvironment)
 import qualified Web.JWT             as JWT
 import qualified Data.Time.Clock.POSIX as Clock
 
-import           AccessControl
-import           JwtAuth
+import           Icepeak.Server.AccessControl
+import           Icepeak.Server.JwtAuth
 
 data Config = Config
   { configJwtSecret      :: Maybe JWT.EncodeSigner

--- a/server/package.yaml
+++ b/server/package.yaml
@@ -57,22 +57,22 @@ library:
   - -fno-ignore-asserts
   - -funbox-strict-fields
   exposed-modules:
-  - AccessControl
-  - Config
-  - Core
-  - HTTPMethodInvalid
-  - HttpServer
-  - JwtAuth
-  - JwtMiddleware
-  - Logger
-  - Metrics
-  - MetricsServer
-  - Persistence
-  - SentryLogging
-  - Server
-  - Store
-  - Subscription
-  - WebsocketServer
+  - Icepeak.Server.AccessControl
+  - Icepeak.Server.Config
+  - Icepeak.Server.Core
+  - Icepeak.Server.HTTPMethodInvalid
+  - Icepeak.Server.HttpServer
+  - Icepeak.Server.JwtAuth
+  - Icepeak.Server.JwtMiddleware
+  - Icepeak.Server.Logger
+  - Icepeak.Server.Metrics
+  - Icepeak.Server.MetricsServer
+  - Icepeak.Server.Persistence
+  - Icepeak.Server.SentryLogging
+  - Icepeak.Server.Server
+  - Icepeak.Server.Store
+  - Icepeak.Server.Subscription
+  - Icepeak.Server.WebsocketServer
 
 executables:
   icepeak:

--- a/server/server.nix
+++ b/server/server.nix
@@ -58,35 +58,39 @@ mkDerivation {
         ./package.yaml
 
         ./tests
-        ./tests/AccessControlSpec.hs
-        ./tests/ApiSpec.hs
-        ./tests/CoreSpec.hs
-        ./tests/JwtSpec.hs
+        ./tests/Icepeak
+        ./tests/Icepeak/Server
+        ./tests/Icepeak/Server/AccessControlSpec.hs
+        ./tests/Icepeak/Server/ApiSpec.hs
+        ./tests/Icepeak/Server/CoreSpec.hs
+        ./tests/Icepeak/Server/JwtSpec.hs
+        ./tests/Icepeak/Server/PersistenceSpec.hs
+        ./tests/Icepeak/Server/RequestSpec.hs
+        ./tests/Icepeak/Server/SocketSpec.hs
+        ./tests/Icepeak/Server/StoreSpec.hs
+        ./tests/Icepeak/Server/SubscriptionTreeSpec.hs
         ./tests/OrphanInstances.hs
-        ./tests/PersistenceSpec.hs
-        ./tests/RequestSpec.hs
-        ./tests/SocketSpec.hs
         ./tests/Spec.hs
-        ./tests/StoreSpec.hs
-        ./tests/SubscriptionTreeSpec.hs
 
         ./src
-        ./src/AccessControl.hs
-        ./src/Config.hs
-        ./src/Core.hs
-        ./src/HTTPMethodInvalid.hs
-        ./src/HttpServer.hs
-        ./src/JwtAuth.hs
-        ./src/JwtMiddleware.hs
-        ./src/Logger.hs
-        ./src/Metrics.hs
-        ./src/MetricsServer.hs
-        ./src/Persistence.hs
-        ./src/SentryLogging.hs
-        ./src/Server.hs
-        ./src/Store.hs
-        ./src/Subscription.hs
-        ./src/WebsocketServer.hs
+        ./src/Icepeak
+        ./src/Icepeak/Server
+        ./src/Icepeak/Server/AccessControl.hs
+        ./src/Icepeak/Server/Config.hs
+        ./src/Icepeak/Server/Core.hs
+        ./src/Icepeak/Server/HTTPMethodInvalid.hs
+        ./src/Icepeak/Server/HttpServer.hs
+        ./src/Icepeak/Server/JwtAuth.hs
+        ./src/Icepeak/Server/JwtMiddleware.hs
+        ./src/Icepeak/Server/Logger.hs
+        ./src/Icepeak/Server/Metrics.hs
+        ./src/Icepeak/Server/MetricsServer.hs
+        ./src/Icepeak/Server/Persistence.hs
+        ./src/Icepeak/Server/SentryLogging.hs
+        ./src/Icepeak/Server/Server.hs
+        ./src/Icepeak/Server/Store.hs
+        ./src/Icepeak/Server/Subscription.hs
+        ./src/Icepeak/Server/WebsocketServer.hs
 
         ./app
         ./app/Icepeak

--- a/server/src/Icepeak/Server/AccessControl.hs
+++ b/server/src/Icepeak/Server/AccessControl.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 -- | This module defines the kinds of permissions used in icepeak and provides
 -- functions checking for sufficient permissions for certain operations.
-module AccessControl
+module Icepeak.Server.AccessControl
        ( AccessMode (..)
        , AuthPath (..)
        , IcepeakClaim (..)
@@ -17,7 +17,7 @@ import qualified Data.Aeson as Aeson
 import qualified Data.List  as List
 import           Data.Text  (Text)
 
-import           Store      (Path)
+import           Icepeak.Server.Store (Path)
 
 -- * Claim datatypes
 

--- a/server/src/Icepeak/Server/Config.hs
+++ b/server/src/Icepeak/Server/Config.hs
@@ -1,4 +1,4 @@
-module Config (
+module Icepeak.Server.Config (
   Config (..),
   MetricsConfig (..),
   StorageBackend (..),

--- a/server/src/Icepeak/Server/Core.hs
+++ b/server/src/Icepeak/Server/Core.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-module Core
+module Icepeak.Server.Core
 (
   Core (..), -- TODO: Expose only put for clients.
   EnqueueResult (..),
@@ -33,15 +33,15 @@ import Data.Traversable (for)
 import Data.UUID (UUID)
 import Prelude hiding (log, writeFile)
 
-import Config (Config (..), periodicSyncingEnabled)
-import Logger (Logger)
-import Store (Path, Modification (..))
-import Subscription (SubscriptionTree, empty)
-import Persistence (PersistentValue, PersistenceConfig (..))
+import Icepeak.Server.Config (Config (..), periodicSyncingEnabled)
+import Icepeak.Server.Logger (Logger)
+import Icepeak.Server.Store (Path, Modification (..))
+import Icepeak.Server.Subscription (SubscriptionTree, empty)
+import Icepeak.Server.Persistence (PersistentValue, PersistenceConfig (..))
 
-import qualified Store
-import qualified Persistence
-import qualified Metrics
+import qualified Icepeak.Server.Store as Store
+import qualified Icepeak.Server.Persistence as Persistence
+import qualified Icepeak.Server.Metrics as Metrics
 
 -- | Defines the kinds of commands that are handled by the event loop of the Core.
 data Command

--- a/server/src/Icepeak/Server/HTTPMethodInvalid.hs
+++ b/server/src/Icepeak/Server/HTTPMethodInvalid.hs
@@ -1,4 +1,4 @@
-module HTTPMethodInvalid (canonicalizeHTTPMethods, limitHTTPMethods) where
+module Icepeak.Server.HTTPMethodInvalid (canonicalizeHTTPMethods, limitHTTPMethods) where
 
 import qualified Network.Wai as Wai
 import qualified Network.HTTP.Types as HTTP

--- a/server/src/Icepeak/Server/HttpServer.hs
+++ b/server/src/Icepeak/Server/HttpServer.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module HttpServer (new) where
+module Icepeak.Server.HttpServer (new) where
 
 import Control.Concurrent.MVar (newEmptyMVar, takeMVar)
 import Control.Monad
@@ -17,14 +17,14 @@ import qualified Data.Text.Lazy as LText
 import qualified Network.Wai as Wai
 import qualified Web.Scotty.Trans as Scotty
 
-import HTTPMethodInvalid (canonicalizeHTTPMethods,limitHTTPMethods)
-import JwtMiddleware (jwtMiddleware)
-import Core (Core (..), EnqueueResult (..))
-import Config (Config (..))
-import Logger (postLog, LogLevel(LogError))
-import qualified Store
-import qualified Core
-import qualified Metrics
+import Icepeak.Server.HTTPMethodInvalid (canonicalizeHTTPMethods,limitHTTPMethods)
+import Icepeak.Server.JwtMiddleware (jwtMiddleware)
+import Icepeak.Server.Core (Core (..), EnqueueResult (..))
+import Icepeak.Server.Config (Config (..))
+import Icepeak.Server.Logger (postLog, LogLevel(LogError))
+import qualified Icepeak.Server.Store as Store
+import qualified Icepeak.Server.Core as Core
+import qualified Icepeak.Server.Metrics as Metrics
 
 new :: Core -> IO Application
 new core =

--- a/server/src/Icepeak/Server/JwtAuth.hs
+++ b/server/src/Icepeak/Server/JwtAuth.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 -- | This module contains all the web framework independent code for parsing and verifying
 -- JSON Web Tokens.
-module JwtAuth where
+module Icepeak.Server.JwtAuth where
 
 import           Control.Monad         ((<=<))
 import qualified Data.Aeson            as Aeson
@@ -14,7 +14,7 @@ import           Data.Time.Clock.POSIX (POSIXTime)
 import           Web.JWT               (JWT, UnverifiedJWT, VerifiedJWT)
 import qualified Web.JWT               as JWT
 
-import           AccessControl
+import           Icepeak.Server.AccessControl
 
 -- * Token verification
 

--- a/server/src/Icepeak/Server/JwtMiddleware.hs
+++ b/server/src/Icepeak/Server/JwtMiddleware.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 -- | This module provides functionality for verifying the JSON Web Tokens in a wai setting.
-module JwtMiddleware where
+module Icepeak.Server.JwtMiddleware where
 
 import           Control.Applicative
 import           Control.Monad
@@ -16,8 +16,8 @@ import qualified Network.HTTP.Types    as Http
 import qualified Network.Wai           as Wai
 import qualified Web.JWT               as JWT
 
-import           AccessControl
-import           JwtAuth
+import           Icepeak.Server.AccessControl
+import           Icepeak.Server.JwtAuth
 
 -- | Defines the kinds of errors that cause authorization to fail.
 data AuthError

--- a/server/src/Icepeak/Server/Logger.hs
+++ b/server/src/Icepeak/Server/Logger.hs
@@ -1,4 +1,4 @@
-module Logger
+module Icepeak.Server.Logger
 (
   Logger,
   LogRecord,
@@ -13,8 +13,8 @@ module Logger
 )
 where
 
-import SentryLogging (getCrashLogger, logCrashMessage)
-import Config (Config, configSentryDSN, configDisableSentryLogging, configQueueCapacity)
+import Icepeak.Server.SentryLogging (getCrashLogger, logCrashMessage)
+import Icepeak.Server.Config (Config, configSentryDSN, configDisableSentryLogging, configQueueCapacity)
 
 import Control.Monad (unless, when, forM_)
 import Control.Concurrent.STM (atomically)

--- a/server/src/Icepeak/Server/Metrics.hs
+++ b/server/src/Icepeak/Server/Metrics.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-module Metrics where
+module Icepeak.Server.Metrics where
 
 import Control.Monad.IO.Class
 import Data.Text (Text, pack)

--- a/server/src/Icepeak/Server/MetricsServer.hs
+++ b/server/src/Icepeak/Server/MetricsServer.hs
@@ -1,13 +1,13 @@
 {-# LANGUAGE OverloadedStrings #-}
-module MetricsServer where
+module Icepeak.Server.MetricsServer where
 
 import           Data.Function                     ((&))
 import qualified Data.Text                         as Text
 import qualified Network.Wai.Handler.Warp          as Warp
 import qualified Network.Wai.Middleware.Prometheus as PrometheusWai
 
-import           Config                            (MetricsConfig (..))
-import           Logger                            (Logger, LogLevel(..), postLog)
+import           Icepeak.Server.Config             (MetricsConfig (..))
+import           Icepeak.Server.Logger             (Logger, LogLevel(..), postLog)
 
 metricsServerConfig :: MetricsConfig -> Warp.Settings
 metricsServerConfig config = Warp.defaultSettings
@@ -16,7 +16,7 @@ metricsServerConfig config = Warp.defaultSettings
 
 runMetricsServer :: Logger -> MetricsConfig -> IO ()
 runMetricsServer logger metricsConfig = do
-  Logger.postLog logger LogInfo $ "Metrics provided on "
+  postLog logger LogInfo $ "Metrics provided on "
     <> (Text.pack $ show $ metricsConfigHost metricsConfig)
     <> ":"
     <> (Text.pack $ show $ metricsConfigPort metricsConfig)

--- a/server/src/Icepeak/Server/Persistence.hs
+++ b/server/src/Icepeak/Server/Persistence.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-| This module abstracts over the details of persisting the value. Journaling is
   also handled here, if enabled. -}
-module Persistence
+module Icepeak.Server.Persistence
   ( PersistentValue
   , PersistenceConfig (..)
   , getDataFile
@@ -36,12 +36,12 @@ import           System.Directory           (getFileSize, renameFile)
 import           System.Exit                (die)
 import           System.IO
 import           System.IO.Error (tryIOError, isDoesNotExistError, isPermissionError)
-import           Logger                     (Logger, LogLevel(..))
-import qualified Logger
-import qualified Metrics
-import qualified Store
+import           Icepeak.Server.Logger      (Logger, LogLevel(..))
+import qualified Icepeak.Server.Logger      as Logger
+import qualified Icepeak.Server.Metrics     as Metrics
+import qualified Icepeak.Server.Store       as Store
 
-import Config (StorageBackend (..))
+import Icepeak.Server.Config (StorageBackend (..))
 
 data PersistentValue = PersistentValue
   { pvConfig       :: PersistenceConfig

--- a/server/src/Icepeak/Server/SentryLogging.hs
+++ b/server/src/Icepeak/Server/SentryLogging.hs
@@ -1,5 +1,5 @@
 -- | Module for logging (crash) reports to Sentry
-module SentryLogging(
+module Icepeak.Server.SentryLogging(
   getCrashLogger, logCrashMessage
 ) where
 

--- a/server/src/Icepeak/Server/Server.hs
+++ b/server/src/Icepeak/Server/Server.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-module Server
+module Icepeak.Server.Server
 (
   runServer,
 )
@@ -14,7 +14,7 @@ import Network.WebSockets (ServerApp)
 import qualified Network.Wai.Handler.Warp as Warp
 import qualified Network.WebSockets as WebSockets
 
-import Logger (Logger, LogLevel(..), postLog)
+import Icepeak.Server.Logger (Logger, LogLevel(..), postLog)
 
 runServer :: Logger -> ServerApp -> Application -> Int -> IO ()
 runServer logger wsApp httpApp port =

--- a/server/src/Icepeak/Server/Store.hs
+++ b/server/src/Icepeak/Server/Store.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-module Store
+module Icepeak.Server.Store
 (
   Modification (..),
   Path,
@@ -73,8 +73,9 @@ lookupOrNull path = fromMaybe Null . lookup path
 
 -- | Execute a modification.
 applyModification :: Modification -> Value -> Value
-applyModification (Delete path) value = Store.delete path value
-applyModification (Put path newValue) value = Store.insert path newValue value
+-- applyModification (Delete path) value = Store.delete path value
+applyModification (Delete path) value = delete path value
+applyModification (Put path newValue) value = insert path newValue value
 
 -- Insert or overwrite a value at the given path, and create the path leading up to it if
 -- it did not exist.

--- a/server/src/Icepeak/Server/Subscription.hs
+++ b/server/src/Icepeak/Server/Subscription.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DeriveFunctor #-}
 
-module Subscription
+module Icepeak.Server.Subscription
 (
   SubscriptionTree (..),
   broadcast,
@@ -24,7 +24,7 @@ import Data.Text (Text)
 import qualified Data.HashMap.Strict as HashMap
 import qualified Data.Text as Text
 
-import qualified Store
+import qualified Icepeak.Server.Store as Store
 
 -- Keeps subscriptions in a tree data structure, so we can efficiently determine
 -- which clients need to be notified for a given update.

--- a/server/src/Icepeak/Server/WebsocketServer.hs
+++ b/server/src/Icepeak/Server/WebsocketServer.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module WebsocketServer (
+module Icepeak.Server.WebsocketServer (
   ServerState,
   acceptConnection,
   processUpdates
@@ -26,14 +26,14 @@ import qualified Network.WebSockets as WS
 import qualified Network.HTTP.Types.Header as HttpHeader
 import qualified Network.HTTP.Types.URI as Uri
 
-import Config (Config (..))
-import Core (Core (..), ServerState, SubscriberState (..), Updated (..), getCurrentValue, withCoreMetrics, newSubscriberState)
-import Store (Path)
-import AccessControl (AccessMode(..))
-import JwtMiddleware (AuthResult (..), isRequestAuthorized, errorResponseBody)
+import Icepeak.Server.Config (Config (..))
+import Icepeak.Server.Core (Core (..), ServerState, SubscriberState (..), Updated (..), getCurrentValue, withCoreMetrics, newSubscriberState)
+import Icepeak.Server.Store (Path)
+import Icepeak.Server.AccessControl (AccessMode(..))
+import Icepeak.Server.JwtMiddleware (AuthResult (..), isRequestAuthorized, errorResponseBody)
 
-import qualified Metrics
-import qualified Subscription
+import qualified Icepeak.Server.Metrics as Metrics
+import qualified Icepeak.Server.Subscription as Subscription
 import Data.Maybe (isJust)
 
 newUUID :: IO UUID

--- a/server/tests/Icepeak/Server/AccessControlSpec.hs
+++ b/server/tests/Icepeak/Server/AccessControlSpec.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-module AccessControlSpec (spec) where
+module Icepeak.Server.AccessControlSpec (spec) where
 
 import Test.Hspec (Spec, describe, it, shouldBe)
 
@@ -7,7 +7,8 @@ import qualified Data.Aeson as Aeson
 import Test.Hspec.QuickCheck (prop)
 import Test.QuickCheck.Instances ()
 
-import AccessControl
+import Icepeak.Server.AccessControl
+
 import OrphanInstances ()
 
 spec :: Spec

--- a/server/tests/Icepeak/Server/ApiSpec.hs
+++ b/server/tests/Icepeak/Server/ApiSpec.hs
@@ -1,4 +1,4 @@
-module ApiSpec (spec) where
+module Icepeak.Server.ApiSpec (spec) where
 
 import Test.Hspec
 

--- a/server/tests/Icepeak/Server/CoreSpec.hs
+++ b/server/tests/Icepeak/Server/CoreSpec.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module CoreSpec (spec) where
+module Icepeak.Server.CoreSpec (spec) where
 
 import Test.Hspec
 

--- a/server/tests/Icepeak/Server/JwtSpec.hs
+++ b/server/tests/Icepeak/Server/JwtSpec.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE OverloadedStrings #-}
-module JwtSpec (spec) where
+module Icepeak.Server.JwtSpec (spec) where
 
 --import qualified Data.Aeson as Aeson
+import Data.Maybe (fromJust)
 import Data.Time.Clock (NominalDiffTime)
 import Test.Hspec -- (Spec, describe, it, shouldBe, expectationFailure)
 import Test.Hspec.QuickCheck (prop)
@@ -10,10 +11,10 @@ import qualified Web.JWT as JWT
 import qualified Data.Map.Strict as Map
 import qualified Data.Text.Encoding as Text
 
-import JwtAuth
-import AccessControl
+import Icepeak.Server.JwtAuth
+import Icepeak.Server.AccessControl
+
 import OrphanInstances ()
-import Data.Maybe (fromJust)
 
 spec :: Spec
 spec = do

--- a/server/tests/Icepeak/Server/PersistenceSpec.hs
+++ b/server/tests/Icepeak/Server/PersistenceSpec.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-module PersistenceSpec (spec) where
+module Icepeak.Server.PersistenceSpec (spec) where
 
 import Data.Foldable
 import Test.Hspec
@@ -9,9 +9,10 @@ import Test.QuickCheck.Instances ()
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as LBS8
 
+import Icepeak.Server.Store (Modification (..))
+import qualified Icepeak.Server.Store as Store
+
 import OrphanInstances ()
-import Store (Modification (..))
-import qualified Store
 
 spec :: Spec
 spec = do

--- a/server/tests/Icepeak/Server/RequestSpec.hs
+++ b/server/tests/Icepeak/Server/RequestSpec.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE OverloadedStrings #-}
-module RequestSpec (spec) where
+module Icepeak.Server.RequestSpec (spec) where
 
 import           Test.Hspec
 import           Test.Hspec.Wai
 
-import           HTTPMethodInvalid (canonicalizeHTTPMethods, limitHTTPMethods)
+import           Icepeak.Server.HTTPMethodInvalid (canonicalizeHTTPMethods, limitHTTPMethods)
 
 import qualified Network.HTTP.Types as HTTP
 import qualified Network.Wai as Wai

--- a/server/tests/Icepeak/Server/SocketSpec.hs
+++ b/server/tests/Icepeak/Server/SocketSpec.hs
@@ -1,4 +1,4 @@
-module SocketSpec (spec) where
+module Icepeak.Server.SocketSpec (spec) where
 
 import Test.Hspec
 

--- a/server/tests/Icepeak/Server/StoreSpec.hs
+++ b/server/tests/Icepeak/Server/StoreSpec.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module StoreSpec (spec) where
+module Icepeak.Server.StoreSpec (spec) where
 
 import Data.Aeson (Value (..))
 import Test.Hspec (Spec, describe, it, shouldBe)
@@ -9,9 +9,10 @@ import Test.QuickCheck.Instances ()
 
 import qualified Data.Aeson.KeyMap as KeyMap
 
+import Icepeak.Server.Store (Modification (..))
+import qualified Icepeak.Server.Store as Store
+
 import OrphanInstances ()
-import Store (Modification (..))
-import qualified Store
 
 spec :: Spec
 spec = do

--- a/server/tests/Icepeak/Server/SubscriptionTreeSpec.hs
+++ b/server/tests/Icepeak/Server/SubscriptionTreeSpec.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module SubscriptionTreeSpec (spec) where
+module Icepeak.Server.SubscriptionTreeSpec (spec) where
 
 import Data.List (sortOn)
 import Test.Hspec (Spec, describe, it, shouldBe)
@@ -11,7 +11,7 @@ import Test.QuickCheck.Instances ()
 import qualified Data.Aeson as AE
 import qualified Data.HashMap.Strict as HM
 
-import Subscription (SubscriptionTree (..), broadcast', empty, subscribe, unsubscribe)
+import Icepeak.Server.Subscription (SubscriptionTree (..), broadcast', empty, subscribe, unsubscribe)
 
 spec :: Spec
 spec = do

--- a/server/tests/OrphanInstances.hs
+++ b/server/tests/OrphanInstances.hs
@@ -4,8 +4,8 @@ import Test.QuickCheck.Instances ()
 import Test.QuickCheck.Arbitrary (Arbitrary (..))
 import qualified Test.QuickCheck.Gen as Gen
 
-import Store (Modification (..))
-import AccessControl
+import Icepeak.Server.Store (Modification (..))
+import Icepeak.Server.AccessControl
 
 instance Arbitrary AccessMode where
   arbitrary = Gen.elements [minBound..maxBound]

--- a/server/tests/Spec.hs
+++ b/server/tests/Spec.hs
@@ -1,23 +1,23 @@
 import Test.Hspec
 
-import qualified AccessControlSpec
-import qualified ApiSpec
-import qualified CoreSpec
-import qualified JwtSpec
-import qualified PersistenceSpec
-import qualified RequestSpec
-import qualified SocketSpec
-import qualified StoreSpec
-import qualified SubscriptionTreeSpec
+import qualified Icepeak.Server.AccessControlSpec
+import qualified Icepeak.Server.ApiSpec
+import qualified Icepeak.Server.CoreSpec
+import qualified Icepeak.Server.JwtSpec
+import qualified Icepeak.Server.PersistenceSpec
+import qualified Icepeak.Server.RequestSpec
+import qualified Icepeak.Server.SocketSpec
+import qualified Icepeak.Server.StoreSpec
+import qualified Icepeak.Server.SubscriptionTreeSpec
 
 main :: IO ()
 main = hspec $ do
-  AccessControlSpec.spec
-  ApiSpec.spec
-  CoreSpec.spec
-  JwtSpec.spec
-  PersistenceSpec.spec
-  RequestSpec.spec
-  SocketSpec.spec
-  StoreSpec.spec
-  SubscriptionTreeSpec.spec
+  Icepeak.Server.AccessControlSpec.spec
+  Icepeak.Server.ApiSpec.spec
+  Icepeak.Server.CoreSpec.spec
+  Icepeak.Server.JwtSpec.spec
+  Icepeak.Server.PersistenceSpec.spec
+  Icepeak.Server.RequestSpec.spec
+  Icepeak.Server.SocketSpec.spec
+  Icepeak.Server.StoreSpec.spec
+  Icepeak.Server.SubscriptionTreeSpec.spec


### PR DESCRIPTION
This is needed before icepeak can be published to Hackage and used as a library in other applications without causing conflicts.

Resolves #108.