### PR TITLE
Add WebSocket time-out handling using the ping mechanism

### DIFF
--- a/server/src/Icepeak/Server/Config.hs
+++ b/server/src/Icepeak/Server/Config.hs
@@ -47,6 +47,11 @@ data Config = Config
   , configSyncLogging :: Bool
   -- | Delay between two pings to the client (useful in order to keep the connexion alive)
   , configWebSocketPingInterval:: Int
+  -- | The timespan in seconds after sending a ping during which the client has
+  -- to respond with a pong. If no pong is sent within this timeout threshold
+  -- then the connection is considered to have timed out and it will be
+  -- terminated.
+  , configWebSocketPongTimeout:: Int
   }
 
 data MetricsConfig = MetricsConfig
@@ -112,6 +117,11 @@ configParser environment = Config
         metavar "WS-PING-INTERVAL" <>
         value 30 <>
         help "The interval of time (in seconds) between two pings to the WebSocket clients. It is instrumental in keeping connections alive.")
+  <*> option auto
+       (long "websocket-pong-timeout" <>
+        metavar "WS-PONG-TIMEOUT" <>
+        value 30 <>
+        help "The timespan in seconds after sending a ping during which the client has to respond with a pong. If no pong is sent within this timeout threshold then the connection is considered to have timed out and it will be terminated.")
 
   where
     environ var = foldMap value (lookup var environment)

--- a/server/src/Icepeak/Server/Server.hs
+++ b/server/src/Icepeak/Server/Server.hs
@@ -8,18 +8,21 @@ where
 import Data.Text (pack)
 
 import Network.Wai (Application)
-import Network.Wai.Handler.WebSockets (websocketsOr)
-import Network.WebSockets (ServerApp)
+import Network.Wai.Handler.WebSockets (isWebSocketsReq, websocketsOr)
 
 import qualified Network.Wai.Handler.Warp as Warp
-import qualified Network.WebSockets as WebSockets
 
 import Icepeak.Server.Logger (Logger, LogLevel(..), postLog)
+import Icepeak.Server.WebsocketServer (WSServerApp, wsConnectionOpts, mkWSServerOptions)
 
-runServer :: Logger -> ServerApp -> Application -> Int -> IO ()
-runServer logger wsApp httpApp port =
-  let
-    wsConnectionOpts = WebSockets.defaultConnectionOptions
-  in do
-    postLog logger LogInfo $ pack $ "Listening on port " <> show port <> "."
-    Warp.run port $ websocketsOr wsConnectionOpts wsApp httpApp
+runServer :: Logger -> WSServerApp -> Application -> Int -> IO ()
+runServer logger wsApp httpApp port = do
+  postLog logger LogInfo $ pack $ "Listening on port " <> show port <> "."
+  Warp.run port $ \req response -> if isWebSocketsReq req
+    then do
+      wsOptions <- mkWSServerOptions
+      -- This should never fall back to 'httpApp' since we already confirmed
+      -- that this is a websocket connection, but the direct 'websocketsApp'
+      -- returns a @Maybe Application@ so this is more robust
+      websocketsOr (wsConnectionOpts wsOptions) (wsApp wsOptions) httpApp req response
+    else httpApp req response

--- a/server/src/Icepeak/Server/WebsocketServer.hs
+++ b/server/src/Icepeak/Server/WebsocketServer.hs
@@ -1,30 +1,39 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Icepeak.Server.WebsocketServer (
+  WSServerApp,
+  -- The constructor is intentionally not exposed since the 'TimeSpec' should be
+  -- initialized using the monotonic clock
+  WSServerOptions(),
+  wsConnectionOpts,
+  mkWSServerOptions,
+
   ServerState,
   acceptConnection,
   processUpdates
 ) where
 
-import Control.Concurrent (modifyMVar_, readMVar)
-import Control.Concurrent.Async (withAsync)
-import Control.Concurrent.MVar (MVar, tryTakeMVar, putMVar, takeMVar)
+import Control.Concurrent (modifyMVar_, readMVar, threadDelay)
+import Control.Concurrent.Async (withAsync, race_)
+import Control.Concurrent.MVar (MVar, newMVar, putMVar, swapMVar, takeMVar, tryTakeMVar)
 import Control.Concurrent.STM (atomically)
 import Control.Concurrent.STM.TBQueue (readTBQueue)
-import Control.Exception (SomeAsyncException, SomeException, finally, fromException, catch, throwIO)
-import Control.Monad (forever, when)
+import Control.Exception (SomeAsyncException, SomeException, finally, fromException, catch, throwIO, AsyncException, handle)
+import Control.Monad (forever, when, void, unless)
 import Data.Aeson (Value)
 import Data.Foldable (for_)
 import Data.Text (Text)
 import Data.UUID
+import System.Clock (Clock (Monotonic), TimeSpec(..), getTime)
 import System.Random (randomIO)
 
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
+import qualified Data.Text as T
 import qualified Data.Time.Clock.POSIX as Clock
-import qualified Network.WebSockets as WS
 import qualified Network.HTTP.Types.Header as HttpHeader
 import qualified Network.HTTP.Types.URI as Uri
+import qualified Network.WebSockets as WS
 
 import Icepeak.Server.Config (Config (..))
 import Icepeak.Server.Core (Core (..), ServerState, SubscriberState (..), Updated (..), getCurrentValue, withCoreMetrics, newSubscriberState)
@@ -35,6 +44,43 @@ import Icepeak.Server.JwtMiddleware (AuthResult (..), isRequestAuthorized, error
 import qualified Icepeak.Server.Metrics as Metrics
 import qualified Icepeak.Server.Subscription as Subscription
 import Data.Maybe (isJust)
+
+-- | 'WS.ServerApp' parameterized over the last received pong timestamp. See
+-- 'WSServerOptions'.
+type WSServerApp = WSServerOptions -> WS.ServerApp
+
+-- | Any additional payload information information used by the websocket
+-- application.
+--
+-- Currently this is only used to keep track of the last received pong. This
+-- value is initialized to the current time when starting the application, and
+-- it is updated in a connection-specific @connectionOnPong@ handler. When a
+-- ping is sent, the IO action in 'withInteruptablePingThread' checks whether
+-- the client answered our last ping with a pong. If it hasn't, then the server
+-- will terminate the websocket connection as timeouts would otherwise leave
+-- zombie connections.
+newtype WSServerOptions = WSServerOptions { wsOptionLastPongTime :: MVar TimeSpec }
+
+-- | Builds the /per connection/-connection settings. This hooks up the
+-- connection's pong handler to the last received pong time MVar so timeouts can
+-- be detected in the ping thread's handlers.
+wsConnectionOpts :: WSServerOptions -> WS.ConnectionOptions
+wsConnectionOpts wsOptions =
+  WS.defaultConnectionOptions
+    { WS.connectionOnPong = pongHandler wsOptions
+    }
+
+-- | Initialize a 'mkWSServerOptions' so it can be used for timeout tracking.
+-- See 'WSServerOptions' for more information.
+mkWSServerOptions :: IO WSServerOptions
+mkWSServerOptions = do
+  -- See 'WSServerOptions' for more information, but this is used to keep track
+  -- of when the last pong was received so the websocket connection can be
+  -- terminated if the client stops sending them. It's initialized with the
+  -- current time so this also works as expected if the client never sends a
+  -- single pong.
+  lastPongTime <- getTime Monotonic
+  WSServerOptions <$> newMVar lastPongTime
 
 newUUID :: IO UUID
 newUUID = randomIO
@@ -58,8 +104,8 @@ broadcast core =
     Subscription.broadcast (writeToSub . subscriberData)
 
 -- Called for each new client that connects.
-acceptConnection :: Core -> WS.PendingConnection -> IO ()
-acceptConnection core pending = do
+acceptConnection :: Core -> WSServerOptions -> WS.PendingConnection -> IO ()
+acceptConnection core wsOptions pending = do
   -- printRequest pending
   -- TODO: Validate the path and headers of the pending request
   authResult <- authorizePendingConnection core pending
@@ -73,12 +119,14 @@ acceptConnection core pending = do
         }
     AuthAccepted -> do
       let path = fst $ Uri.decodePath $ WS.requestPath $ WS.pendingRequest pending
-          pingInterval = configWebSocketPingInterval $ coreConfig core
+          config = coreConfig core
+          pingInterval = configWebSocketPingInterval config
+          onPing = pingHandler config wsOptions
       connection <- WS.acceptRequest pending
       -- Fork a pinging thread, for each client, to keep idle connections open and to detect
       -- closed connections. Sends a ping message every 30 seconds.
       -- Note: The thread dies silently if the connection crashes or is closed.
-      WS.withPingThread connection pingInterval (pure ()) $ handleClient connection path core
+      withInteruptablePingThread connection pingInterval onPing $ handleClient connection path core
 
 -- * Authorization
 
@@ -173,3 +221,67 @@ processUpdates core = go
           go
         -- Stop the loop when we receive a Nothing.
         Nothing -> pure ()
+
+-- * Timeout handling
+--
+-- The websockets library lets you send pings, but it has no built in way to
+-- terminate clients that never send a pong back. We implement this ourselves by
+-- keeping track of when we last received a pong, and then terminating the
+-- connection if the time between the last sent ping and the last received pong
+-- exceeds a certain threshold. See 'WSServerOptions' for more information
+
+-- | The connection-specific on-pong handler. This writes the time at which the
+-- last pong was received so 'pingHandler' can terminate the connection if the
+-- client stops sending pongs back.
+pongHandler :: WSServerOptions -> IO ()
+pongHandler (WSServerOptions lastPongTime) = getTime Monotonic >>= void . swapMVar lastPongTime
+
+-- | An action passed to 'withInteruptablePingThread' that is used together with
+-- 'pongHandler' to terminates a websocket connection if the client stops
+-- sending timely pongs. This returns @True@ if the connection has timed out and
+-- should be terminated.
+pingHandler :: Config -> WSServerOptions -> IO Bool
+pingHandler config (WSServerOptions lastPongTime) = do
+  now <- getTime Monotonic
+  let pingInterval     = TimeSpec (fromIntegral $ configWebSocketPingInterval config) 0
+      pongTimeout      = TimeSpec (fromIntegral $ configWebSocketPongTimeout config) 0
+      lastPongDeadline = now - pingInterval - pongTimeout
+
+  lastPong <- readMVar lastPongTime
+  return $! lastPong < lastPongDeadline
+
+-- | Similar to 'WS.withPingThread', except that it uses a combination of
+-- 'pingHandler' and the 'pongHandler' set in the websocket connection's pong
+-- handler to detect that the thread client stopped sending pongs. If that
+-- happens the @app@ action will be canceled immediately.
+--
+-- The @pingAction@ is exected on every ping, and it should return @True@ if the
+-- client has timed out and the connection should be terminated.
+withInteruptablePingThread :: WS.Connection -> Int -> IO Bool -> IO () -> IO ()
+withInteruptablePingThread conn pingInterval pingAction =
+  race_ (interuptablePingThread conn pingInterval pingAction)
+
+-- | 'WS.pingTHread', with the only real difference being that it takes an @IO
+-- Bool@ instead of an @IO ()@ action. If that action returns true, then the
+-- ping thread will return early causing 'withInteruptablePingThread' to
+-- terminate as well.
+interuptablePingThread :: WS.Connection -> Int -> IO Bool -> IO ()
+interuptablePingThread conn pingInterval pingAction
+  | pingInterval <= 0 = return ()
+  | otherwise = ignore `handle` go 1
+  where
+    go :: Int -> IO ()
+    go i = do
+      threadDelay (pingInterval * 1000 * 1000)
+      WS.sendPing conn (T.pack $ show i)
+      -- The difference with the original 'pingTHread' is that this action now
+      -- returns a boolean, and we'll terminate this thread when that action
+      -- returns true
+      hasTimedOut <- pingAction
+      unless hasTimedOut $ go (i + 1)
+
+    -- The rest of this function is exactly the same as the 'pingThread' in
+    -- @websockets-0.12.7.3@
+    ignore e = case fromException e of
+      Just async -> throwIO (async :: AsyncException)
+      Nothing -> return ()


### PR DESCRIPTION
As mentioned in #104, the while the websockets library does have a function that spawns a thread to periodically ping clients to keep the connection alive and to make sure the client hasn't timed out, it doesn't actually implement the latter part on its own (see https://github.com/jaspervdj/websockets/issues/159).

This implementation works by detecting timeouts, and then cancelling the websocket `app` action when that happens. The timeout detection is implemented by making sure the long pong was received within a certain time frame of the last sent ping whenever a new ping is sent. When that happens, the ping handler thread exits which causes the app action to exit as well thanks to the use of `race_` in `withInteruptablePingThread`. The original library-provided `withPingThread` runs the ping handler on its own thread with no clean way for the ping handler to affect the thread the `app` action is running on due to the use of `withAsync` (but without actually using the async value at any point).

The last piece of the puzzle is the pong handler, which is set through the `ConnectionOptions`. These options were previously shared for all connections, so a small refactor had to be made to allow different options for each connection.

Let me know if there are any questions or if anyone has suggestions on how to improve this. I found the easiest way to test this to be by launching the server with short timeouts (e.g. `stack run -- --websocket-ping-interval=1 --websocket-pong-timeout=1`), and then using websocat to connect to the server (`websocat ws://localhost:3000 -vvvv --print-ping-rtts`), sending `SIGSTOP`/pressing Ctrl+Z to simulate a timeout.

Fixes  #104.