### PR TITLE
Add content-type header to PUT request in client

### DIFF
--- a/client-haskell/src/Icepeak/Client.hs
+++ b/client-haskell/src/Icepeak/Client.hs
@@ -120,11 +120,12 @@ deleteAtLeafRequest = deleteAtLeafRequestWithOptions defaultRequestOptions
 -- | Return a HTTP request for setting a value at the leaf of a path.
 setAtLeafRequestWithOptions :: ToJSON a => RequestOptions -> Config -> [Text] -> a -> HTTP.Request
 setAtLeafRequestWithOptions options config path leaf =
-  (baseRequest config)
-    { HTTP.method = "PUT"
-    , HTTP.path = requestPathForIcepeakPath path (optionsToQuery options)
-    , HTTP.requestBody = HTTP.RequestBodyLBS (Aeson.encode leaf)
-    }
+  let req = (baseRequest config)
+   in req { HTTP.method = "PUT"
+          , HTTP.path = requestPathForIcepeakPath path (optionsToQuery options)
+          , HTTP.requestBody = HTTP.RequestBodyLBS (Aeson.encode leaf)
+          , HTTP.requestHeaders = ("Content-Type", "application/json"):(HTTP.requestHeaders req)
+          }
 
 -- | Return a HTTP request for deleting a value at the leaf of a path.
 deleteAtLeafRequestWithOptions :: RequestOptions -> Config -> [Text] -> HTTP.Request


### PR DESCRIPTION
Attach the appropriate "Content-Type" header when sending a PUT request from the client.

Found this bug because axum expects requests with a JSON body to have this header set to the appropriate value.