### PR TITLE
Multi Subscription Single Connection

### DIFF
--- a/docs/IcepeakProtocolMultiSub.md
+++ b/docs/IcepeakProtocolMultiSub.md
@@ -13,14 +13,13 @@ The URL path:
 - points to the root of your icepeak service
 - has the query parameter `method` set to `reusable`
 
-The request should contain:
-- a token of autherisation about the right to establish a connection with the server **UNDER-SPECIFIED** 
+The authorisation method follows the same protocol as the previous one.
 
 # Subscribing, Unsubscribing & Updates
 
 In summary:
 - The client can request to subscribe to an array of paths.
-- The client, on the single connection, can cummulavely keep subscribing and unsubscribing to paths by sending corresponding payloads.
+- The client, on the single connection, can cumulatively keep subscribing and unsubscribing to paths by sending corresponding payloads.
   - The server also sends back a response about the status, and some data of the corresponding subscription or unsubscription request.
 - The server will send the client the new value/update at the subscribed path whenever there is a change at that path.
 - Both, subscription and unsubscription requests are idempotent.

--- a/docs/IcepeakProtocolMultiSub.md
+++ b/docs/IcepeakProtocolMultiSub.md
@@ -13,7 +13,7 @@ The URL path:
 - points to the root of your icepeak service
 - has the query parameter `method` set to `reusable`
 
-The authorisation mechanism is a "subscription deadline timout": Initial websocket connection does not need authorisation, but if the client does not subscribe to a client before the server-configured timeout, then the connection will be closed.
+The authorisation mechanism is a "subscription deadline timout": Initial websocket connection does not need authorisation, but if the client does not subscribe to a client before the server-configured timeout, then the connection will be closed un-politely, i.e the server will not send a WS close control message.
 
 Timeout is set by the `--first-subscription-deadline-timeout` flag, the input is in terms of microseconds, the default value is `100000` (0.1 seconds).
 

--- a/docs/IcepeakProtocolMultiSub.md
+++ b/docs/IcepeakProtocolMultiSub.md
@@ -54,7 +54,7 @@ In summary:
   - The client has to send a JWT that authorises all the paths.
 - The client can expect a response from the server that contains the status/acknowledgement of the request.
   - Upon a successful request, the client can expect the payload to also contain the current value of the paths requested.
-  
+
 ### Client Subscribe Request
 Each subscription is checked against a JWT to see if the user is authorised to access the path(s).
 

--- a/docs/IcepeakProtocolMultiSub.md
+++ b/docs/IcepeakProtocolMultiSub.md
@@ -15,7 +15,7 @@ The URL path:
 
 The authorisation mechanism is a "subscription deadline timout": Initial websocket connection does not need authorisation, but if the client does not subscribe to a client before the server-configured timeout, then the connection will be closed un-politely, i.e the server will not send a WS close control message.
 
-Timeout is set by the `--first-subscription-deadline-timeout` flag, the input is in terms of microseconds, the default value is `100000` (0.1 seconds).
+Timeout is set by the `--first-subscription-deadline-timeout` flag, the input is in terms of microseconds, the default value is `1000000` (1 second).
 
 
 # Subscribing, Unsubscribing & Updates

--- a/docs/IcepeakProtocolMultiSub.md
+++ b/docs/IcepeakProtocolMultiSub.md
@@ -1,0 +1,177 @@
+# The Icepeak Multiple-Subcription-Single-Connection Protocol
+
+This protocol was developed atop the existing protocol to allow the client to subscribe to multiple "paths"/"topics" using a single websocket connection.
+
+Whereas the original existing protocol required a new websocket connection for each path the client wanted to subscribe to.
+
+# Initial Connection
+
+A client can connect to a multiple-subscription protocol connection with a URL such as:
+`ws://yourdomain.com/?method=reusable`
+
+The URL path:
+- points to the root of your icepeak service
+- has the query parameter `method` set to `reusable`
+
+The request should contain:
+- a token of autherisation about the right to establish a connection with the server **UNDER-SPECIFIED** 
+
+# Subscribing, Unsubscribing & Updates
+
+In summary:
+- The client can request to subscribe to an array of paths.
+- The client, on the single connection, can cummulavely keep subscribing and unsubscribing to paths by sending corresponding payloads.
+  - The server also sends back a response about the status, and some data of the corresponding subscription or unsubscription request.
+- The server will send the client the new value/update at the subscribed path whenever there is a change at that path.
+- Both, subscription and unsubscription requests are idempotent.
+
+## Update
+
+`JSON Schema` declaration of the update the server will send to the client upon subscribed path change:
+```javascript
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "wss://updates.channable.com",
+  "title": "Path changes",
+  "description": "Indicates changes occurred at the subscribed paths",
+  "type": "object",
+  "properties": {
+    "type": { "const": "update" },
+    "change": {
+      "type": "object",
+      "properties": {
+        "path": { "type": "string" },
+        "value": {}
+      }
+    }
+  }
+}
+```
+
+## Subscribe
+
+In summary:
+- The client can send a payload that contains an array of paths to subscribe to.
+  - The client has to send a JWT that authorises all the paths.
+- The client can expect a response from the server that contains the status/acknowledgement of the request.
+  - Upon a successful request, the client can expect the payload to also contain the current value of the paths requested.
+  
+### Client Subscribe Request
+Each subscription is checked against a JWT to see if the user is authorised to access the path(s).
+
+`JSON Schema` declaration of the subscribe client request:
+```javascript
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "wss://updates.channable.com/",
+  "title": "Add subscription",
+  "description": "Adding an additional subscription",
+  "type": "object",
+  "properties": {
+    "type": { "const": "subscribe" },
+    "paths": { "type": "array", "items": { "type": "string" } },
+    "token": { "type": "string" }
+  }
+}
+```
+
+### Server Subscribe Response
+The server sends back a payload to the client. The payload will always contain a status code:
+
+| Status code | When                                  |
+| ---- | -------------------------------------------- |
+| 200  | Subscription was successfully processed      |
+| 400  | Request payload was malformed                |
+| 401  | No authorization token provided              |
+| 403  | Authorization token was rejected / malformed |
+
+
+If the status code is `200` and **whether or not the client is already subscribed**, the client can expect a payload from server that contains:
+- The status code.
+- Path(s) of the subscription requested.
+- The current value(s) of that path(s).
+
+`JSON Schema` declaration of the server response:
+```javascript
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "wss://updates.channable.com",
+  "title": "Subscription status",
+  "description": "Indicates whether the subscription was successful",
+  "type": "object",
+  "properties": {
+    "type": { "const": "subscribe" },
+    "paths": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "path": { "type": "string" },
+          "value": {}
+        }
+      }
+    },
+    "code": { "type": "number" },
+    "message": { "type": "string" },
+    "extra": {}
+  }
+}
+```
+
+## Unsubscribe
+
+In summary:
+- The client can send a payload that contains paths to unsubscribe from.
+- The client can expect a response from the server that contains the status/acknowledgement of the request.
+  - In the case of a successful request, the response also contains the list of paths in the client request.
+
+### Client Unsubscribe Request
+
+`JSON Schema` declaration of the unsubscribe client request:
+```javascript
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "wss://updates.channable.com",
+  "title": "Remove Subscription",
+  "description": "Remove an existing subscription",
+  "type": "object",
+  "properties": {
+    "type": { "const": "unsubscribe" },
+    "paths": { "type": "array", "items": { "type": "string" } }
+  }
+}
+```
+
+### Server Unsubscribe Response
+The server sends back a payload to the client. The payload will always contain a status code:
+
+| Status code   | When                             |
+| ------------- | -------------------------------- |
+| 200  | Unsubscription was successfully processed |
+| 400  | Request payload was malformed             |
+
+If the status code is `200` and **whether or not the client is already unsubscribed**, the client can expect a payload from server that contains:
+- the list of the unsubscribe paths that the client had sent in the request.
+
+`JSON Schema` declaration of the unsubscribe client request:
+```javascript
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "wss://updates.channable.com",
+  "title": "Unsubscription status",
+  "description": "Indicates whether the unsubscription was successful",
+  "type": "object",
+  "properties": {
+    "type": { "const": "unsubscribe" },
+    "paths": { "type": "array", "items": { "type": "string" } },
+    "code": { "type": "number" },
+    "message": { "type": "string" },
+    "extra": {}
+  }
+}
+```
+
+
+
+# Invalid Client Message
+The server will close the websocket connection if the client payload contains an unrecognised `type`.

--- a/server/icepeak.cabal
+++ b/server/icepeak.cabal
@@ -37,6 +37,7 @@ library
     Icepeak.Server.WebsocketServer.SingleSubscription
     Icepeak.Server.WebsocketServer.MultiSubscription
     Icepeak.Server.WebsocketServer.Payload
+    Icepeak.Server.WebsocketServer.Utils
 
   other-modules:    Paths_icepeak
   hs-source-dirs:   src

--- a/server/icepeak.cabal
+++ b/server/icepeak.cabal
@@ -34,6 +34,9 @@ library
     Icepeak.Server.Store
     Icepeak.Server.Subscription
     Icepeak.Server.WebsocketServer
+    Icepeak.Server.WebsocketServer.SingleSubscription
+    Icepeak.Server.WebsocketServer.MultiSubscription
+    Icepeak.Server.WebsocketServer.Payload
 
   other-modules:    Paths_icepeak
   hs-source-dirs:   src
@@ -177,6 +180,7 @@ test-suite spec
     Icepeak.Server.SocketSpec
     Icepeak.Server.StoreSpec
     Icepeak.Server.SubscriptionTreeSpec
+    Icepeak.Server.MultiSubscriptionSpec
     OrphanInstances
     Paths_icepeak
 
@@ -223,5 +227,6 @@ test-suite spec
     , wai-websockets
     , warp
     , websockets
+    , hspec-expectations-json
 
   default-language: Haskell2010

--- a/server/icepeak.nix
+++ b/server/icepeak.nix
@@ -5,8 +5,9 @@
 
 # Haskell packages
 , aeson, async, base, bytestring, clock, containers, directory, hashable, hspec
-, hspec-wai, http-types, jwt, monad-logger, mtl, network, optparse-applicative
-, prometheus-client, prometheus-metrics-ghc, QuickCheck, quickcheck-instances
+, hspec-wai, hspec-expectations-json, http-types, jwt, monad-logger, mtl, network
+, optparse-applicative, prometheus-client
+, prometheus-metrics-ghc, QuickCheck, quickcheck-instances
 , random, raven-haskell, scotty, sqlite-simple, securemem, stm, text, time, unix
 , unordered-containers, uuid, wai, wai-extra, wai-middleware-prometheus
 , wai-websockets, warp, websockets }:
@@ -83,7 +84,7 @@ mkDerivation {
     websockets
   ];
 
-  testHaskellDepends = [ hspec hspec-wai QuickCheck quickcheck-instances ];
+  testHaskellDepends = [ hspec hspec-wai QuickCheck quickcheck-instances hspec-expectations-json ];
 
   license = lib.licenses.bsd3;
 }

--- a/server/src/Icepeak/Server/Config.hs
+++ b/server/src/Icepeak/Server/Config.hs
@@ -131,7 +131,7 @@ configParser environment = Config
   <*> option auto
        (long "first-subscription-deadline-timeout" <>
         metavar "MICROSECONDS" <>
-        value 100_000 <> -- 0.1 seconds
+        value 1_000_000 <> -- 1 second
         help "The amount of time in microseconds to wait for a subscription request before closing the connection. This is used for the multiple subscription protocol. The initial connection to the server is not behind authorisation, and hence this timeout mechanism is used to disconnect unwanted connections.")
 
   where

--- a/server/src/Icepeak/Server/Config.hs
+++ b/server/src/Icepeak/Server/Config.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NumericUnderscores #-}
+
 module Icepeak.Server.Config (
   Config (..),
   MetricsConfig (..),
@@ -51,6 +53,11 @@ data Config = Config
   -- to respond with a pong. If no pong is sent within this timeframe then the
   -- connection is considered to have timed out and it will be terminated.
   , configWebSocketPongTimeout:: Int
+  -- | The amount of time in microseconds to wait for a subscription request before closing the connection.
+  -- This is used for the 'MultiSubscription.hs' protocol.
+  -- The initial connection to the server is not behind authorisation, this timeout mechanism
+  -- is used to prevent unwanted connections.
+  , configInitialSubscriptionTimeoutMicroSeconds:: Int
   }
 
 data MetricsConfig = MetricsConfig
@@ -121,6 +128,11 @@ configParser environment = Config
         metavar "WS-PONG-TIMEOUT" <>
         value 30 <>
         help "The timespan in seconds after sending a ping during which the client has to respond with a pong. If no pong is sent within this timeframe then the connection is considered to have timed out and it will be terminated.")
+  <*> option auto
+       (long "first-subscription-deadline-timeout" <>
+        metavar "MICROSECONDS" <>
+        value 100_000 <> -- 0.1 seconds
+        help "The amount of time in microseconds to wait for a subscription request before closing the connection. This is used for the multiple subscription protocol. The initial connection to the server is not behind authorisation, and hence this timeout mechanism is used to disconnect unwanted connections.")
 
   where
     environ var = foldMap value (lookup var environment)

--- a/server/src/Icepeak/Server/Core.hs
+++ b/server/src/Icepeak/Server/Core.hs
@@ -73,10 +73,11 @@ data Core = Core
   }
 
 
--- This structure keeps track of all subscribers. We use one SubscriberState per
--- subscriber.
-type ServerState =
-  SubscriptionTree UUID ((MVar Value -> Value -> IO ()) -> Value -> IO ())
+-- This structure keeps track of all subscribers.
+-- Each subscriber is associated with a function for how to notify them.
+-- This is a a flexability in order to support the multiple protcols that
+-- exist for subscribing, i.e 'MultiSubscription.hs' and 'SingleSubscription.hs'.
+type ServerState = SubscriptionTree UUID (Value -> IO ())
 
 newServerState :: ServerState
 newServerState = empty

--- a/server/src/Icepeak/Server/Core.hs
+++ b/server/src/Icepeak/Server/Core.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
-module Icepeak.Server.Core
-(
+
+module Icepeak.Server.Core (
   Core (..), -- TODO: Expose only put for clients.
   EnqueueResult (..),
   Command (..),
@@ -14,14 +14,14 @@ module Icepeak.Server.Core
   newCore,
   postQuit,
   runCommandLoop,
-  runSyncTimer
+  runSyncTimer,
 )
 where
 
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.MVar (MVar, newMVar, putMVar)
 import Control.Concurrent.STM (atomically)
-import Control.Concurrent.STM.TBQueue (TBQueue, newTBQueueIO, readTBQueue, writeTBQueue, isFullTBQueue)
+import Control.Concurrent.STM.TBQueue (TBQueue, isFullTBQueue, newTBQueueIO, readTBQueue, writeTBQueue)
 import Control.Concurrent.STM.TVar (TVar, newTVarIO)
 import Control.Monad (forever, unless, when)
 import Control.Monad.IO.Class
@@ -33,13 +33,13 @@ import Prelude hiding (log, writeFile)
 
 import Icepeak.Server.Config (Config (..), periodicSyncingEnabled)
 import Icepeak.Server.Logger (Logger)
-import Icepeak.Server.Store (Path, Modification (..))
+import Icepeak.Server.Persistence (PersistenceConfig (..), PersistentValue)
+import Icepeak.Server.Store (Modification (..), Path)
 import Icepeak.Server.Subscription (SubscriptionTree, empty)
-import Icepeak.Server.Persistence (PersistentValue, PersistenceConfig (..))
 
-import qualified Icepeak.Server.Store as Store
-import qualified Icepeak.Server.Persistence as Persistence
 import qualified Icepeak.Server.Metrics as Metrics
+import qualified Icepeak.Server.Persistence as Persistence
+import qualified Icepeak.Server.Store as Store
 
 -- | Defines the kinds of commands that are handled by the event loop of the Core.
 data Command
@@ -61,17 +61,16 @@ data EnqueueResult = Enqueued | Dropped
 
 data Core = Core
   { coreCurrentValue :: PersistentValue
-  -- the "dirty" flag is set to True whenever the core value has been modified
-  -- and is reset to False when it is persisted.
-  , coreValueIsDirty :: TVar Bool
-  , coreQueue        :: TBQueue Command
-  , coreUpdates      :: TBQueue (Maybe Updated)
-  , coreClients      :: MVar ServerState
-  , coreLogger       :: Logger
-  , coreConfig       :: Config
-  , coreMetrics      :: Maybe Metrics.IcepeakMetrics
+  , -- the "dirty" flag is set to True whenever the core value has been modified
+    -- and is reset to False when it is persisted.
+    coreValueIsDirty :: TVar Bool
+  , coreQueue :: TBQueue Command
+  , coreUpdates :: TBQueue (Maybe Updated)
+  , coreClients :: MVar ServerState
+  , coreLogger :: Logger
+  , coreConfig :: Config
+  , coreMetrics :: Maybe Metrics.IcepeakMetrics
   }
-
 
 -- This structure keeps track of all subscribers.
 -- Each subscriber is associated with a function for how to notify them.
@@ -87,18 +86,23 @@ newCore :: Config -> Logger -> Maybe Metrics.IcepeakMetrics -> IO (Either String
 newCore config logger metrics = do
   let queueCapacity = fromIntegral . configQueueCapacity $ config
   -- load the persistent data from disk
-  let filePath = Persistence.getDataFile (configStorageBackend config) (configDataFile config)
-      journalFile
-        | configEnableJournaling config
-          && periodicSyncingEnabled config = Just $ filePath ++ ".journal"
-        | otherwise = Nothing
-  eitherValue <- Persistence.loadFromBackend (configStorageBackend config) PersistenceConfig
-    { pcDataFile = filePath
-    , pcJournalFile = journalFile
-    , pcLogger = logger
-    , pcMetrics = metrics
-    , pcLogSync = configSyncLogging config
-    }
+  let
+    filePath = Persistence.getDataFile (configStorageBackend config) (configDataFile config)
+    journalFile
+      | configEnableJournaling config
+          && periodicSyncingEnabled config =
+          Just $ filePath ++ ".journal"
+      | otherwise = Nothing
+  eitherValue <-
+    Persistence.loadFromBackend
+      (configStorageBackend config)
+      PersistenceConfig
+        { pcDataFile = filePath
+        , pcJournalFile = journalFile
+        , pcLogger = logger
+        , pcMetrics = metrics
+        , pcLogSync = configSyncLogging config
+        }
   for eitherValue $ \value -> do
     -- create synchronization channels
     tdirty <- newTVarIO False
@@ -142,7 +146,7 @@ getCurrentValue :: Core -> Path -> IO (Maybe Value)
 getCurrentValue core path =
   fmap (Store.lookup path) $ atomically $ Persistence.getValue $ coreCurrentValue core
 
-withCoreMetrics :: MonadIO m => Core -> (Metrics.IcepeakMetrics -> IO ()) -> m ()
+withCoreMetrics :: (MonadIO m) => Core -> (Metrics.IcepeakMetrics -> IO ()) -> m ()
 withCoreMetrics core act = liftIO $ forM_ (coreMetrics core) act
 
 -- | Drain the command queue and execute them. Changes are published to all
@@ -150,27 +154,27 @@ withCoreMetrics core act = liftIO $ forM_ (coreMetrics core) act
 -- queue.
 runCommandLoop :: Core -> IO ()
 runCommandLoop core = go
-  where
-    config = coreConfig core
-    currentValue = coreCurrentValue core
-    storageBackend = configStorageBackend config
-    go = do
-      command <- atomically $ readTBQueue (coreQueue core)
-      for_ (coreMetrics core) Metrics.incrementQueueRemoved
-      case command of
-        Modify op maybeNotifyVar -> do
-          Persistence.apply op currentValue
-          postUpdate (Store.modificationPath op) core
-          -- when periodic syncing is disabled, data is persisted after every modification
-          unless (periodicSyncingEnabled $ coreConfig core) $
-            Persistence.syncToBackend storageBackend currentValue
-          mapM_ (`putMVar` ()) maybeNotifyVar
-          go
-        Sync -> do
-          maybe id Metrics.measureSyncDuration (coreMetrics core) $
-            Persistence.syncToBackend storageBackend currentValue
-          go
-        Stop -> Persistence.syncToBackend storageBackend currentValue
+ where
+  config = coreConfig core
+  currentValue = coreCurrentValue core
+  storageBackend = configStorageBackend config
+  go = do
+    command <- atomically $ readTBQueue (coreQueue core)
+    for_ (coreMetrics core) Metrics.incrementQueueRemoved
+    case command of
+      Modify op maybeNotifyVar -> do
+        Persistence.apply op currentValue
+        postUpdate (Store.modificationPath op) core
+        -- when periodic syncing is disabled, data is persisted after every modification
+        unless (periodicSyncingEnabled $ coreConfig core) $
+          Persistence.syncToBackend storageBackend currentValue
+        mapM_ (`putMVar` ()) maybeNotifyVar
+        go
+      Sync -> do
+        maybe id Metrics.measureSyncDuration (coreMetrics core) $
+          Persistence.syncToBackend storageBackend currentValue
+        go
+      Stop -> Persistence.syncToBackend storageBackend currentValue
 
 -- | Post an update to the core's update queue (read by the websocket subscribers)
 postUpdate :: Path -> Core -> IO ()
@@ -184,15 +188,14 @@ postUpdate path core = do
     return full
   for_ (coreMetrics core) $
     if isWsQueueFull
-    then Metrics.incrementWsQueueSkippedUpdates
-    else Metrics.incrementWsQueueAdded
+      then Metrics.incrementWsQueueSkippedUpdates
+      else Metrics.incrementWsQueueAdded
 
 -- | Periodically send a 'Sync' command to the 'Core' if enabled in the core
 -- configuration.
 runSyncTimer :: Core -> IO ()
 runSyncTimer core = mapM_ go (configSyncIntervalMicroSeconds $ coreConfig core)
-  where
-    go interval = forever $ do
-      enqueueCommand Sync core
-      threadDelay interval
-
+ where
+  go interval = forever $ do
+    enqueueCommand Sync core
+    threadDelay interval

--- a/server/src/Icepeak/Server/WebsocketServer.hs
+++ b/server/src/Icepeak/Server/WebsocketServer.hs
@@ -13,22 +13,19 @@ module Icepeak.Server.WebsocketServer (
   processUpdates
 ) where
 
-import Control.Concurrent (modifyMVar_, readMVar, threadDelay)
-import Control.Concurrent.Async (race_, withAsync)
-import Control.Concurrent.MVar (MVar, putMVar, takeMVar, tryTakeMVar)
+import Control.Concurrent (readMVar, threadDelay)
+import Control.Concurrent.Async (race_)
+import Control.Concurrent.MVar (MVar, putMVar, tryTakeMVar)
 import Control.Concurrent.STM (atomically)
 import Control.Concurrent.STM.TBQueue (readTBQueue)
-import Control.Exception (AsyncException, SomeAsyncException, SomeException, catch, finally, fromException, handle, throwIO)
-import Control.Monad (forever, unless, void, when)
+import Control.Exception (AsyncException, fromException, handle, throwIO)
+import Control.Monad (unless, void, when)
 import Data.Aeson (Value)
 import Data.Foldable (for_)
 import Data.IORef (IORef, atomicWriteIORef, readIORef, newIORef)
 import Data.Text (Text)
-import Data.UUID
 import System.Clock (Clock (Monotonic), TimeSpec (..), getTime)
-import System.Random (randomIO)
 
-import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Text as T
 import qualified Data.Time.Clock.POSIX as Clock
@@ -37,10 +34,12 @@ import qualified Network.HTTP.Types.URI as Uri
 import qualified Network.WebSockets as WS
 
 import Icepeak.Server.Config (Config (..))
-import Icepeak.Server.Core (Core (..), ServerState, SubscriberState (..), Updated (..), getCurrentValue, withCoreMetrics, newSubscriberState)
-import Icepeak.Server.Store (Path)
+import Icepeak.Server.Core (Core (..), ServerState, Updated (..))
 import Icepeak.Server.AccessControl (AccessMode(..))
 import Icepeak.Server.JwtMiddleware (AuthResult (..), isRequestAuthorized, errorResponseBody)
+
+import qualified Icepeak.Server.WebsocketServer.SingleSubscription as SingleSubscription
+import qualified Icepeak.Server.WebsocketServer.MultiSubscription as MultiSubscription
 
 import qualified Icepeak.Server.Metrics as Metrics
 import qualified Icepeak.Server.Subscription as Subscription
@@ -84,9 +83,6 @@ mkWSServerOptions = do
   lastPongTime <- getTime Monotonic
   WSServerOptions <$> newIORef lastPongTime
 
-newUUID :: IO UUID
-newUUID = randomIO
-
 -- send the updated data to all subscribers to the path
 broadcast :: Core -> [Text] -> Value -> ServerState -> IO ()
 broadcast core =
@@ -102,111 +98,10 @@ broadcast core =
       -- that the update has been skipped.
       when (isJust mbQueue) $ for_ (coreMetrics core) Metrics.incrementWsSkippedUpdates
       putMVar queue val
-  in
-    Subscription.broadcast (writeToSub . subscriberData)
 
--- Called for each new client that connects.
-acceptConnection :: Core -> WSServerOptions -> WS.PendingConnection -> IO ()
-acceptConnection core wsOptions pending = do
-  -- printRequest pending
-  -- TODO: Validate the path and headers of the pending request
-  authResult <- authorizePendingConnection core pending
-  case authResult of
-    AuthRejected err ->
-      WS.rejectRequestWith pending $ WS.RejectRequest
-        { WS.rejectCode = 401
-        , WS.rejectMessage = "Unauthorized"
-        , WS.rejectHeaders = [(HttpHeader.hContentType, "application/json")]
-        , WS.rejectBody = LBS.toStrict $ errorResponseBody err
-        }
-    AuthAccepted -> do
-      let path = fst $ Uri.decodePath $ WS.requestPath $ WS.pendingRequest pending
-          config = coreConfig core
-          pingInterval = configWebSocketPingInterval config
-          onPing = pingHandler config wsOptions
-      connection <- WS.acceptRequest pending
-      -- Fork a pinging thread, for each client, to keep idle connections open and to detect
-      -- closed connections. Sends a ping message every 30 seconds.
-      -- Note: The thread dies silently if the connection crashes or is closed.
-      withInterruptiblePingThread connection pingInterval onPing $ handleClient connection path core
+    modifySubscriberState subUpdateCallback = subUpdateCallback writeToSub
 
--- * Authorization
-
-authorizePendingConnection :: Core -> WS.PendingConnection -> IO AuthResult
-authorizePendingConnection core conn
-  | configEnableJwtAuth (coreConfig core) = do
-      now <- Clock.getPOSIXTime
-      let req = WS.pendingRequest conn
-          (path, query) = Uri.decodePath $ WS.requestPath req
-          headers = WS.requestHeaders req
-      return $ isRequestAuthorized headers query now (configJwtSecret (coreConfig core)) path ModeRead
-  | otherwise = pure AuthAccepted
-
--- * Client handling
-
-handleClient :: WS.Connection -> Path -> Core -> IO ()
-handleClient conn path core = do
-  uuid <- newUUID
-  subscriberState <- newSubscriberState
-  let
-    state = coreClients core
-    onConnect = do
-      modifyMVar_ state (pure . Subscription.subscribe path uuid subscriberState)
-      withCoreMetrics core Metrics.incrementSubscribers
-    onDisconnect = do
-      modifyMVar_ state (pure . Subscription.unsubscribe path uuid)
-      withCoreMetrics core Metrics.decrementSubscribers
-    sendInitialValue = do
-      currentValue <- getCurrentValue core path
-      WS.sendTextData conn (Aeson.encode currentValue)
-    -- For each connection, we want to spawn a client thread with an associated
-    -- queue, in order to manage subscribers. `withAsync` acts as `forkIO` in this
-    -- context, with the assurance the child thread is killed when the parent is.
-    manageConnection = withAsync (updateThread conn subscriberState)
-                                 (const $ keepTalking conn)
-
-    -- Simply ignore connection errors, otherwise, Warp handles the exception
-    -- and sends a 500 response in the middle of a WebSocket connection, and
-    -- that violates the WebSocket protocol.
-    -- Note that subscribers are still properly removed by the finally below.
-    handleConnectionError :: WS.ConnectionException -> IO ()
-    handleConnectionError _ = pure ()
-  -- Put the client in the subscription tree and keep the connection open.
-  -- Remove it when the connection is closed.
-  finally (onConnect >> sendInitialValue >> manageConnection) onDisconnect
-    `catch` handleConnectionError
-
--- This function handles sending the updates to subscribers.
-updateThread :: WS.Connection -> SubscriberState -> IO ()
-updateThread conn state =
-  let
-    send :: Value -> IO ()
-    send value =
-      WS.sendTextData conn (Aeson.encode value)
-      `catch`
-      sendFailed
-
-    sendFailed :: SomeException -> IO ()
-    sendFailed exc
-      -- Rethrow async exceptions, they are meant for inter-thread communication
-      -- (e.g. ThreadKilled) and we don't expect them at this point.
-      | Just asyncExc <- fromException exc = throwIO (asyncExc :: SomeAsyncException)
-      -- We want to catch all other errors in order to prevent them from
-      -- bubbling up and disrupting the broadcasts to other clients.
-      | otherwise = pure ()
-  in forever $ do
-      value <- takeMVar $ subscriberData state
-      send value
-
--- We don't send any messages here; sending is done by the update
--- loop; it finds the client in the set of subscriptions. But we do
--- need to keep the thread running, otherwise the connection will be
--- closed. So we go into an infinite loop here.
-keepTalking :: WS.Connection -> IO ()
-keepTalking conn = forever $ do
-    -- Note: WS.receiveDataMessage will handle control messages automatically and e.g.
-    -- do the closing handshake of the websocket protocol correctly
-    WS.receiveDataMessage conn
+  in Subscription.broadcast modifySubscriberState
 
 -- loop that is called for every update and that broadcasts the values to all
 -- subscribers of the updated path
@@ -223,6 +118,57 @@ processUpdates core = go
           go
         -- Stop the loop when we receive a Nothing.
         Nothing -> pure ()
+
+-- Called for each new client that connects.
+acceptConnection :: Core -> WSServerOptions -> WS.PendingConnection -> IO ()
+acceptConnection core wsOptions pending = do
+  -- printRequest pending
+  -- TODO: Validate the path and headers of the pending request
+  authResult <- authorizePendingConnection core pending
+  case authResult of
+    AuthRejected err ->
+      WS.rejectRequestWith pending $ WS.RejectRequest
+        { WS.rejectCode = 401
+        , WS.rejectMessage = "Unauthorized"
+        , WS.rejectHeaders = [(HttpHeader.hContentType, "application/json")]
+        , WS.rejectBody = LBS.toStrict $ errorResponseBody err
+        }
+    AuthAccepted -> do
+      let (path, queryParams) = Uri.decodePath $ WS.requestPath $ WS.pendingRequest pending
+          config = coreConfig core
+          pingInterval = configWebSocketPingInterval config
+          onPing = pingHandler config wsOptions
+      connection <- WS.acceptRequest pending
+      -- Fork a pinging thread, for each client, to keep idle connections open and to detect
+      -- closed connections. Sends a ping message every 30 seconds.
+      -- Note: The thread dies silently if the connection crashes or is closed.
+      
+      let runHandleClient = withInterruptiblePingThread connection pingInterval onPing
+      case lookup "method" queryParams of
+        Nothing -> runHandleClient
+          $ SingleSubscription.handleClient connection path core
+        Just (Just "reusable") -> runHandleClient
+          $ MultiSubscription.handleClient connection core
+        Just _ ->
+          WS.rejectRequestWith pending $ WS.RejectRequest
+          { WS.rejectCode = 400
+          , WS.rejectMessage = "Unrecognised query parameter value"
+          , WS.rejectHeaders = [(HttpHeader.hContentType, "text/plain")]
+          , WS.rejectBody = "Invalid 'method' query parameter value, expecting 'reusable'"
+          }
+
+
+-- * Authorization
+
+authorizePendingConnection :: Core -> WS.PendingConnection -> IO AuthResult
+authorizePendingConnection core conn
+  | configEnableJwtAuth (coreConfig core) = do
+      now <- Clock.getPOSIXTime
+      let req = WS.pendingRequest conn
+          (path, query) = Uri.decodePath $ WS.requestPath req
+          headers = WS.requestHeaders req
+      return $ isRequestAuthorized headers query now (configJwtSecret (coreConfig core)) path ModeRead
+  | otherwise = pure AuthAccepted
 
 -- * Timeout handling
 --

--- a/server/src/Icepeak/Server/WebsocketServer.hs
+++ b/server/src/Icepeak/Server/WebsocketServer.hs
@@ -142,7 +142,7 @@ acceptConnection core wsOptions pending = do
       -- Fork a pinging thread, for each client, to keep idle connections open and to detect
       -- closed connections. Sends a ping message every 30 seconds.
       -- Note: The thread dies silently if the connection crashes or is closed.
-      
+
       let runHandleClient = withInterruptiblePingThread connection pingInterval onPing
       case lookup "method" queryParams of
         Nothing -> runHandleClient

--- a/server/src/Icepeak/Server/WebsocketServer/MultiSubscription.hs
+++ b/server/src/Icepeak/Server/WebsocketServer/MultiSubscription.hs
@@ -20,7 +20,6 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Data.Time.Clock.POSIX as Clock
 import qualified Network.WebSockets as WS
-import qualified System.Random as Random
 import qualified Web.JWT as JWT
 
 import Icepeak.Server.Config (Config)
@@ -34,11 +33,9 @@ import qualified Icepeak.Server.Core as Core
 import qualified Icepeak.Server.JwtAuth as JwtAuth
 import qualified Icepeak.Server.Metrics as Metrics
 import qualified Icepeak.Server.Subscription as Subscription
+import qualified Icepeak.Server.WebsocketServer.Utils as Utils
 
 -- * Client handling
-
-newUUID :: IO UUID
-newUUID = Random.randomIO
 
 -- ** Sending Response Payloads
 
@@ -312,7 +309,7 @@ onDisconnect client = do
 
 handleClient :: WS.Connection -> Core -> IO ()
 handleClient conn core = do
-  uuid <- newUUID
+  uuid <- Utils.newUUID
   isDirty <- MVar.newMVar ()
   subscriptions <- MVar.newMVar (HashMap.empty :: HashMap [Text] (MVar Value))
 

--- a/server/src/Icepeak/Server/WebsocketServer/MultiSubscription.hs
+++ b/server/src/Icepeak/Server/WebsocketServer/MultiSubscription.hs
@@ -327,11 +327,12 @@ handleClient conn core = do
       Async.withAsync
         (startUpdaterThread client)
         -- It's important that the below action is the outer action of the `withAsync` as
-        -- we rely on the Exceptions the outer action throws for 3 reasons:
-        -- 1. To cancel the inner "updaterThread" action when the outer action throws.
+        -- we rely on the Exceptions the outer action throws for 4 reasons:
+        -- 1. For `withAsync` to kill the inner "updaterThread" thread when the outer action throws.
         -- 2. To propagate the SubscriptionTimeout exception from the `withSubscribeTimeout`.
         -- 3. To propagate the ConnectionException from the `receiveDataMessage` that is
-        --    used within the "messageHandlerThread".
+        --    thrown within the "messageHandlerThread".
+        -- 4. So that `onDisconnect` runs, see that `manageConnection` is in a `finally`.
         ( const $
             withSubscribeTimeout
               client

--- a/server/src/Icepeak/Server/WebsocketServer/MultiSubscription.hs
+++ b/server/src/Icepeak/Server/WebsocketServer/MultiSubscription.hs
@@ -99,20 +99,18 @@ onPayloadSubscribeWithAuth
   -> JWT.VerifySigner
   -> RequestSubscribe
   -> IO ()
-
 onPayloadSubscribeWithAuth client secret (RequestSubscribe paths mbToken) = do
   let conn = clientConn client
   case mbToken of
     Nothing -> do
       WS.sendTextData conn $ -- 401  | No authorization token provided
         Aeson.encode $
-        ResponseSubscribeFailure
-        { subscribeFailureStatusCode = 401
-        , subscribeFailureMessage = "No authorisation token provided"
-        , subscribeFailureExtraData = Nothing
-        , subscribeFailurePaths = Just paths
-        }
-
+          ResponseSubscribeFailure
+            { subscribeFailureStatusCode = 401
+            , subscribeFailureMessage = "No authorisation token provided"
+            , subscribeFailureExtraData = Nothing
+            , subscribeFailurePaths = Just paths
+            }
     Just tokenBS -> do
       let segmentedPaths = Text.splitOn "/" <$> paths :: [Path]
       now <- Clock.getPOSIXTime
@@ -272,10 +270,10 @@ onPayload coreConfig client (RequestPayloadSubscribe requestSubscribe) = do
     jwtSecret = Config.configJwtSecret coreConfig
 
   case (jwtEnabled, jwtSecret) of
-    (True , Just secret) -> onPayloadSubscribeWithAuth client secret requestSubscribe
-    (False, Just _)      -> onPayloadSubscribeNoAuth client requestSubscribe
-    (True , Nothing)     -> onPayloadSubscribeNoAuth client requestSubscribe
-    (False, Nothing)     -> onPayloadSubscribeNoAuth client requestSubscribe
+    (True, Just secret) -> onPayloadSubscribeWithAuth client secret requestSubscribe
+    (False, Just _) -> onPayloadSubscribeNoAuth client requestSubscribe
+    (True, Nothing) -> onPayloadSubscribeNoAuth client requestSubscribe
+    (False, Nothing) -> onPayloadSubscribeNoAuth client requestSubscribe
 onPayload _ client (RequestPayloadUnsubscribe requestUnsubscribe) =
   onPayloadUnsubscribe client requestUnsubscribe
 onPayload _ client (RequestPayloadMalformed malformedPayload) =
@@ -287,8 +285,8 @@ onMessage client = do
     coreConfig = Core.coreConfig $ clientCore client
     conn = clientConn client
   dataMessage <- WS.receiveDataMessage conn
-  onPayload coreConfig client
-    $ parseDataMessage dataMessage
+  onPayload coreConfig client $
+    parseDataMessage dataMessage
 
 onConnect :: Client -> IO ()
 onConnect client =

--- a/server/src/Icepeak/Server/WebsocketServer/MultiSubscription.hs
+++ b/server/src/Icepeak/Server/WebsocketServer/MultiSubscription.hs
@@ -1,0 +1,389 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Icepeak.Server.WebsocketServer.MultiSubscription (handleClient) where
+
+
+import Control.Concurrent.MVar (MVar)
+import qualified Control.Concurrent.Async as Async
+import qualified Control.Concurrent.MVar  as MVar
+
+import qualified Control.Exception as Exception
+import qualified Control.Monad     as Monad
+
+import Data.Functor  ((<&>))
+import qualified Data.Maybe    as Maybe
+
+import Data.HashMap.Strict (HashMap)
+import qualified Data.HashMap.Strict as HashMap
+
+import Data.Text (Text)
+import qualified Data.Text          as Text
+import qualified Data.Text.Encoding as Text
+
+import Data.Aeson (Value, (.=))
+import qualified Data.Aeson as Aeson
+
+import Data.UUID (UUID)
+import qualified Data.Time.Clock.POSIX as Clock
+import qualified System.Random         as Random
+
+import qualified Web.JWT               as JWT
+import qualified Network.WebSockets    as WS
+
+
+import Icepeak.Server.WebsocketServer.Payload
+import Icepeak.Server.Core (Core)
+import Icepeak.Server.Store (Path)
+import Icepeak.Server.Config (Config)
+import qualified Icepeak.Server.Config                  as Config
+import qualified Icepeak.Server.Core                    as Core
+import qualified Icepeak.Server.Metrics                 as Metrics
+import qualified Icepeak.Server.Subscription            as Subscription
+import qualified Icepeak.Server.JwtAuth                 as JwtAuth
+import qualified Icepeak.Server.AccessControl           as Access
+
+-- * Client handling
+
+newUUID :: IO UUID
+newUUID = Random.randomIO
+
+-- ** Sending Response Payloads
+
+data Client = Client
+  { clientConn :: WS.Connection
+  , clientUuid :: UUID
+  , clientCore :: Core
+  , clientIsDirty :: MVar ()
+  , clientSubscriptions :: MVar (HashMap Path (MVar Value))
+  }
+
+
+doSubscribe :: Client -> [Path] -> IO ()
+doSubscribe client paths = do
+  let
+    core = clientCore client
+    conn = clientConn client
+    
+    uuid          = clientUuid client
+    isDirty       = clientIsDirty client
+    subscriptions = clientSubscriptions client
+
+    coreClients = Core.coreClients core
+
+  pathsWithCurrentValue <- Monad.forM paths $
+    \path -> do
+      valueAtPath <- Core.getCurrentValue core path
+      pure (Text.intercalate "/" path, valueAtPath)
+
+  WS.sendTextData conn
+    $ Aeson.encode
+    $ ResponseSubscribeSuccess
+    { subscribeSuccessPathsValues = pathsWithCurrentValue }
+    
+  -- WARNING: Race condition, potentially miss an update when program is at this point 
+
+  Monad.forM_ paths $ \newPath -> do
+    pathValueMVar <- MVar.newEmptyMVar
+
+    MVar.modifyMVar_ subscriptions
+      (pure . HashMap.insert newPath pathValueMVar)
+
+    MVar.modifyMVar_ coreClients
+      (pure . Subscription.subscribe newPath uuid
+        (\writeToSub newValue -> do
+            writeToSub pathValueMVar newValue
+            Monad.void $ MVar.tryPutMVar isDirty ()))
+
+
+onPayloadSubscribeWithAuth
+  :: Client
+  -> JWT.VerifySigner
+  -> RequestSubscribe
+  -> IO ()
+onPayloadSubscribeWithAuth client _ (RequestSubscribe paths Nothing) = do
+  let conn = clientConn client
+  WS.sendTextData conn -- 401  | No authorization token provided
+    $ Aeson.encode
+    $ ResponseSubscribeFailure
+    { subscribeFailureStatusCode = 401
+    , subscribeFailureMessage = "No authorisation token provided"
+    , subscribeFailureExtraData = Nothing
+    , subscribeFailurePaths = Just paths }
+    
+onPayloadSubscribeWithAuth client secret (RequestSubscribe paths (Just tokenBS)) = do
+  let conn = clientConn client
+      segmentedPaths = Text.splitOn "/" <$> paths :: [Path]
+  now <- Clock.getPOSIXTime
+  case JwtAuth.extractClaim now secret (Text.encodeUtf8 tokenBS) of
+    Left tokenError -> do -- 403  | Authorization token was rejected / malformed |
+      WS.sendTextData conn
+        $ Aeson.encode
+        $ ResponseSubscribeFailure
+        { subscribeFailureStatusCode = 403
+        , subscribeFailureMessage = "Error while extracting claim from JWT: " <> Text.pack (show tokenError)
+        , subscribeFailureExtraData = Nothing
+        , subscribeFailurePaths = Just paths }
+
+    Right authenticatedIcePeakClaim -> do
+      let pathsIsAuth = segmentedPaths <&>
+            (\path -> ( path
+                      , Access.isAuthorizedByClaim authenticatedIcePeakClaim path Access.ModeRead
+                      ))
+          allAuth = and $ snd <$> pathsIsAuth
+      if allAuth
+        then doSubscribe client segmentedPaths
+        else WS.sendTextData conn -- 403  | Authorization token was rejected / malformed |
+             $ Aeson.encode
+             $ ResponseSubscribeFailure
+             { subscribeFailureStatusCode = 403
+             , subscribeFailureMessage = "Some paths are not authorised by the provided JWT claim"
+             , subscribeFailureExtraData = Just
+               $ Aeson.object [ "unauthorisedPaths" .= (fst <$> filter (not . snd) pathsIsAuth) ]
+             , subscribeFailurePaths = Just paths }
+
+onPayloadSubscribeNoAuth
+  :: Client
+  -> RequestSubscribe
+  -> IO ()
+onPayloadSubscribeNoAuth client (RequestSubscribe paths _) = do
+  let segmentedPaths = Text.splitOn "/" <$> paths :: [Path]
+  doSubscribe client segmentedPaths
+
+onPayloadUnsubscribe
+  :: Client
+  -> RequestUnsubscribe
+  -> IO ()
+onPayloadUnsubscribe client (RequestUnsubscribe paths) = do
+  let
+    conn = clientConn client
+    core = clientCore client
+
+    segmentedPaths = Text.splitOn "/" <$> paths :: [Path]
+
+    uuid          = clientUuid client
+    subscriptions = clientSubscriptions client
+
+    coreClients = Core.coreClients core
+
+  Monad.forM_ segmentedPaths $ \path -> do
+    MVar.modifyMVar_ coreClients
+      (pure . Subscription.unsubscribe path uuid)
+
+    MVar.modifyMVar_ subscriptions
+      (pure . HashMap.delete path)
+
+  WS.sendTextData conn
+    $ Aeson.encode
+    $ ResponseUnsubscribeSuccess { unsubscribeSuccessPaths = paths }
+
+  
+onPayloadMalformed
+  :: Client
+  -> RequestMalformedError
+  -> IO ()
+onPayloadMalformed client requestMalformedError = do
+  let
+    conn = clientConn client
+
+    closeConnection :: CloseType -> IO ()
+    closeConnection closeType = do
+      -- NOTE:
+      -- This will issue a control message to the peer.
+      -- The connection will stay alive, and we will be expecting
+      -- the peer to eventually respond with a close control message
+      -- of its own, which will cause receiveDataMessage to
+      -- throw a CloseRequest exception.
+      WS.sendCloseCode conn
+        (closeCode closeType)
+        (closeMessage closeType)
+
+    respondMalformedSubscribe :: Text -> IO ()
+    respondMalformedSubscribe extra = do
+      WS.sendTextData conn
+        $ Aeson.encode
+        $ ResponseSubscribeFailure
+        { subscribeFailureStatusCode = 400
+        , subscribeFailureMessage = "Subscribe request payload is malformed"
+        , subscribeFailureExtraData = Just $ Aeson.toJSON extra
+        , subscribeFailurePaths = Nothing }
+
+    respondMalformedUnsubscribe :: Text -> IO ()
+    respondMalformedUnsubscribe extra = do
+      WS.sendTextData conn
+        $ Aeson.encode
+        $ ResponseUnsubscribeFailure
+        { unsubscribeFailureStatusCode = 400
+        , unsubscribeFailureMessage = "Unsubscribe request payload is malformed"
+        , unsubscribeFailurePaths = Nothing
+        , unsubscribeFailureExtraData = Just $ Aeson.toJSON extra
+        }
+
+  case requestMalformedError of
+    PayloadSizeOutOfBounds
+      -> closeConnection TypeSizeOutOfBounds
+    UnexpectedBinaryPayload
+      -> closeConnection TypeBinaryPayload
+    JsonDecodeError _decodeError
+      -> closeConnection TypeJsonDecodeError
+    PayloadNotAnObject
+      -> closeConnection TypePayloadNotObject
+    MissingOrUnexpectedType _unexpectedType
+      -> closeConnection TypeMissingOrUnexpectedType
+
+    SubscribePathsMissingOrMalformed pathsParseError
+      -> respondMalformedSubscribe
+         $ "Subscribe paths are missing or malformed: " <> pathsParseError
+    SubscribeTokenNotAString tokenParseError
+      -> respondMalformedSubscribe
+         $ "Subscribe token is not a string: " <> tokenParseError
+    UnsubscribePathsMissingOrMalformed pathsParseError
+      -> respondMalformedUnsubscribe
+         $ "Unsubscribe paths are missing or malformed: " <> pathsParseError
+
+-- | Explicit enumeration of the procedures that
+-- the server will perform given a request.
+data PayloadAction
+  = ActionSubscribeWithAuth JWT.VerifySigner RequestSubscribe
+  | ActionSubscribeNoAuth RequestSubscribe
+  | ActionUnsubscribe RequestUnsubscribe
+  | ActionError RequestMalformedError
+
+-- | Determine the server action based on the request and config.
+-- `Core.Config` is needed to determine if auth is enabled, otherwise the
+-- `PayloadAction` can be determined purely from the parsed `RequestPayload`.
+determinePayloadAction
+  :: Config -> RequestPayload -> PayloadAction
+  
+determinePayloadAction coreConfig (RequestPayloadSubscribe requestSubscribe) = do
+  let
+    jwtEnabled = Config.configEnableJwtAuth coreConfig
+    jwtSecret = Config.configJwtSecret coreConfig
+    
+  case (jwtEnabled, jwtSecret) of
+    (True, Just secret) -> ActionSubscribeWithAuth secret requestSubscribe
+    (False, Just _ )    -> ActionSubscribeNoAuth requestSubscribe
+    (True , Nothing)    -> ActionSubscribeNoAuth requestSubscribe
+    (False, Nothing)    -> ActionSubscribeNoAuth requestSubscribe
+
+determinePayloadAction _ (RequestPayloadUnsubscribe requestUnsubscribe)
+  = ActionUnsubscribe requestUnsubscribe
+
+determinePayloadAction _ (RequestPayloadMalformed malformedPayload)
+  = ActionError malformedPayload
+
+-- | Peform the payload action. We pass the `Client` argument, which
+-- heavily implies impure things are to happen, namely:
+--  - Mutating `Core` MVars
+--  - Using `Conn`
+--  - Mutating `Client` MVars
+performPayloadAction
+  :: Client -> PayloadAction -> IO ()
+performPayloadAction client payloadAction =
+  case payloadAction of
+    ActionSubscribeWithAuth secret requestSubscribe
+      -> onPayloadSubscribeWithAuth client secret requestSubscribe
+    ActionSubscribeNoAuth requestSubscribe
+      -> onPayloadSubscribeNoAuth client requestSubscribe
+    ActionUnsubscribe requestUnsubscribe
+      -> onPayloadUnsubscribe client requestUnsubscribe
+    ActionError requestMalformed
+      -> onPayloadMalformed client requestMalformed
+
+onMessage :: Client -> IO ()
+onMessage client = do
+  let coreConfig = Core.coreConfig $ clientCore client
+      conn = clientConn client
+  dataMessage <- WS.receiveDataMessage conn
+  performPayloadAction client
+    $ determinePayloadAction coreConfig
+    $ parseDataMessage dataMessage
+
+onConnect :: Client -> IO ()
+onConnect client =
+  Core.withCoreMetrics (clientCore client) Metrics.incrementSubscribers
+
+onDisconnect :: Client -> IO ()
+onDisconnect client = do
+  let
+    core = clientCore client
+    subscriptions = clientSubscriptions client
+    uuid = clientUuid client
+
+  paths <-  HashMap.keys <$> MVar.takeMVar subscriptions
+  Monad.forM_ paths
+    (\path -> MVar.modifyMVar_ (Core.coreClients core)
+      (pure . Subscription.unsubscribe path uuid))
+
+  Core.withCoreMetrics core Metrics.decrementSubscribers
+
+handleClient :: WS.Connection -> Core -> IO ()
+handleClient conn core = do
+  uuid          <- newUUID
+  isDirty       <- MVar.newMVar ()
+  subscriptions <- MVar.newMVar (HashMap.empty :: HashMap [Text] (MVar Value))
+
+  let
+    client = Client
+      { clientConn = conn
+      , clientUuid = uuid
+      , clientCore = core
+      , clientIsDirty = isDirty
+      , clientSubscriptions = subscriptions
+      }
+
+    manageConnection = Async.withAsync
+      (updateThread client)
+      (const $ Monad.forever $ onMessage client)
+
+    -- Simply ignore connection errors, otherwise, Warp handles the exception
+    -- and sends a 500 response in the middle of a WebSocket connection, and
+    -- that violates the WebSocket protocol.
+    -- Note that subscribers are still properly removed by the finally below.
+    handleConnectionError :: WS.ConnectionException -> IO ()
+    handleConnectionError _ = pure ()
+  -- Put the client in the subscription tree and keep the connection open.
+  -- Remove it when the connection is closed.
+  Exception.finally (onConnect client >> manageConnection) (onDisconnect client)
+    `Exception.catch` handleConnectionError
+
+
+takeMVarUpdatedValues :: Client -> IO [(Text, Value)]
+takeMVarUpdatedValues client = do
+  let
+    isDirty = clientIsDirty client
+    subscriptions = clientSubscriptions client
+  MVar.takeMVar isDirty
+  valueMVars <- HashMap.toList <$> MVar.readMVar subscriptions
+  Maybe.catMaybes <$> (Monad.forM valueMVars $
+    \(path, valueMVar) ->
+      fmap (\v -> (Text.intercalate "/" path, v))
+      <$> MVar.tryTakeMVar valueMVar)
+
+
+-- This function handles sending the updates to subscribers.
+updateThread :: Client -> IO ()
+updateThread client =
+  let
+    conn = clientConn client
+
+    send :: Text -> Value -> IO ()
+    send path value =
+      Exception.catch 
+      (WS.sendTextData conn $
+        Aeson.encode $ Update path value)
+      sendFailed
+
+    sendFailed :: Exception.SomeException -> IO ()
+    sendFailed exc
+      -- Rethrow async exceptions, they are meant for inter-thread communication
+      -- (e.g. ThreadKilled) and we don't expect them at this point.
+      | Just asyncExc <- Exception.fromException exc = Exception.throwIO (asyncExc :: Exception.SomeAsyncException)
+      -- We want to catch all other errors in order to prevent them from
+      -- bubbling up and disrupting the broadcasts to other clients.
+      | otherwise = pure ()
+
+  in Monad.forever $ do
+    value <- takeMVarUpdatedValues client
+    mapM (uncurry send) value

--- a/server/src/Icepeak/Server/WebsocketServer/MultiSubscription.hs
+++ b/server/src/Icepeak/Server/WebsocketServer/MultiSubscription.hs
@@ -363,8 +363,9 @@ handleClient conn core = do
     handleSubscriptionTimeout :: SubscriptionTimeout -> IO ()
     handleSubscriptionTimeout _ = pure ()
 
-  -- Put the client in the subscription tree and keep the connection open.
-  -- Remove it when the connection is closed.
+  -- Run the threads to propagate updates to client, and to receive and handle payloads
+  -- Upon threads dying, unsubscribe client from all subscriptions, then exit the procedure
+  -- to let `wai-websockets` close the websocket stream (since we are in a bracket)
   Exception.finally
     (onConnect client >> manageConnection)
     (onDisconnect client)

--- a/server/src/Icepeak/Server/WebsocketServer/Payload.hs
+++ b/server/src/Icepeak/Server/WebsocketServer/Payload.hs
@@ -111,7 +111,7 @@ instance Aeson.ToJSON ResponseSubscribeFailure where
           Just paths -> [ "paths" .= paths ]
           Nothing  -> []
 
-data ResponseUnsubscribeSuccess
+newtype ResponseUnsubscribeSuccess
   = ResponseUnsubscribeSuccess
   { unsubscribeSuccessPaths :: [Text]
   }

--- a/server/src/Icepeak/Server/WebsocketServer/Payload.hs
+++ b/server/src/Icepeak/Server/WebsocketServer/Payload.hs
@@ -203,8 +203,8 @@ parseDataMessage
 parseDataMessage (WebSockets.Binary _) = RequestPayloadMalformed UnexpectedBinaryPayload
 parseDataMessage (WebSockets.Text utf8EncodedLazyByteString _) =
   case parsedPayload of
-    (Left malformed) -> RequestPayloadMalformed malformed
-    (Right (Left subscribe)) -> RequestPayloadSubscribe subscribe
+    (Left malformed)            -> RequestPayloadMalformed malformed
+    (Right (Left subscribe))    -> RequestPayloadSubscribe subscribe
     (Right (Right unsubscribe)) -> RequestPayloadUnsubscribe unsubscribe
  where
   parsedPayload

--- a/server/src/Icepeak/Server/WebsocketServer/Payload.hs
+++ b/server/src/Icepeak/Server/WebsocketServer/Payload.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE TypeApplications #-}
 
-
 module Icepeak.Server.WebsocketServer.Payload where
 
 import qualified Network.WebSockets as WebSockets
@@ -68,13 +67,6 @@ instance Aeson.ToJSON Update where
     ]  
 
 -- * Response
-
-data ResponsePayload
-  = ResponsePayloadSubscribeSuccess ResponseSubscribeSuccess
-  | ResponsePayloadeSubscribeFailure ResponseSubscribeFailure
-  | ResponsePayloadUnsubscribeSuccess ResponseUnsubscribeSuccess
-  | ResponsePayloadUnsubscribeFailure ResponseUnsubscribeFailure
-
 
 data ResponseSubscribeSuccess
   = ResponseSubscribeSuccess

--- a/server/src/Icepeak/Server/WebsocketServer/Payload.hs
+++ b/server/src/Icepeak/Server/WebsocketServer/Payload.hs
@@ -155,9 +155,7 @@ data CloseType
 
 -- https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/close#parameters
 
--- Status codes in the range 3000-3999 are reserved for use by
--- libraries, frameworks, and applications. The interpretation of these codes
--- is undefined by this protocol.
+-- Status codes in the range 3000-3999 are reserved for use by libraries, frameworks, and applications.
 
 closeCode :: CloseType -> Word16
 closeCode TypeSizeOutOfBounds = 3001
@@ -203,8 +201,8 @@ parseDataMessage
 parseDataMessage (WebSockets.Binary _) = RequestPayloadMalformed UnexpectedBinaryPayload
 parseDataMessage (WebSockets.Text utf8EncodedLazyByteString _) =
   case parsedPayload of
-    (Left malformed)            -> RequestPayloadMalformed malformed
-    (Right (Left subscribe))    -> RequestPayloadSubscribe subscribe
+    (Left malformed) -> RequestPayloadMalformed malformed
+    (Right (Left subscribe)) -> RequestPayloadSubscribe subscribe
     (Right (Right unsubscribe)) -> RequestPayloadUnsubscribe unsubscribe
  where
   parsedPayload

--- a/server/src/Icepeak/Server/WebsocketServer/Payload.hs
+++ b/server/src/Icepeak/Server/WebsocketServer/Payload.hs
@@ -1,0 +1,274 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE TypeApplications #-}
+
+
+module Icepeak.Server.WebsocketServer.Payload where
+
+import qualified Network.WebSockets as WebSockets
+
+import Data.Functor ((<&>))
+import qualified Data.Bifunctor as Bifunctor
+
+import Data.Aeson (Value, (.=), (.:), (.:?))
+import qualified Data.Aeson       as Aeson
+import qualified Data.Aeson.Types as Aeson
+
+import Data.Text (Text)
+import qualified Data.Text as Text
+
+import qualified Data.ByteString.Lazy as Lazy (ByteString)
+import qualified Data.ByteString as ByteString
+import qualified Data.ByteString.Lazy.Internal as Lazy.ByteString
+
+import Data.Word (Word16)
+
+-- * Request
+
+data RequestPayload
+  = RequestPayloadSubscribe RequestSubscribe
+  | RequestPayloadUnsubscribe RequestUnsubscribe
+  | RequestPayloadMalformed RequestMalformedError
+
+data RequestSubscribe = RequestSubscribe
+  { requestSubscribePaths :: [Text]
+  , requestSubscribeToken :: Maybe Text
+  }
+
+data RequestUnsubscribe = RequestUnsubscribe
+  { requestUnsubscribePaths :: [Text]
+  }
+
+data RequestMalformedError
+  = PayloadSizeOutOfBounds
+  | UnexpectedBinaryPayload
+
+  | JsonDecodeError Text
+  | PayloadNotAnObject
+  | MissingOrUnexpectedType Text
+
+  | SubscribePathsMissingOrMalformed Text
+  | SubscribeTokenNotAString Text
+
+  | UnsubscribePathsMissingOrMalformed Text
+  deriving Show
+
+-- * Update
+
+data Update = Update
+  { updatePath :: Text
+  , updateValue :: Value }
+
+instance Aeson.ToJSON Update where
+  toJSON (Update path value) =
+    Aeson.object
+    [ "type"  .= ("update" :: Text)
+    , "path" .= path
+    , "value" .= value
+    ]  
+
+-- * Response
+
+data ResponsePayload
+  = ResponsePayloadSubscribeSuccess ResponseSubscribeSuccess
+  | ResponsePayloadeSubscribeFailure ResponseSubscribeFailure
+  | ResponsePayloadUnsubscribeSuccess ResponseUnsubscribeSuccess
+  | ResponsePayloadUnsubscribeFailure ResponseUnsubscribeFailure
+
+
+data ResponseSubscribeSuccess
+  = ResponseSubscribeSuccess
+  { subscribeSuccessPathsValues :: [( Text, Maybe Value)] }
+
+instance Aeson.ToJSON ResponseSubscribeSuccess where
+  toJSON (ResponseSubscribeSuccess pathsValues) =
+    Aeson.object
+    [ "type"  .= ("subscribe" :: Text)
+    , "code" .= (200 :: Int)
+    , "message" .= ("You've been successfully subscribed to the paths" :: Text)
+    , "extra" .= Aeson.object [] 
+    , "paths" .=
+      (pathsValues <&>
+        \(path, value) ->
+          Aeson.object [ "path" .= path, "value" .= value ])
+    ]
+
+data ResponseSubscribeFailure
+  = ResponseSubscribeFailure
+  { subscribeFailureStatusCode :: Int
+  , subscribeFailureMessage :: Text
+  , subscribeFailurePaths :: Maybe [Text]
+  , subscribeFailureExtraData :: Maybe Value
+  }
+
+instance Aeson.ToJSON ResponseSubscribeFailure where
+  toJSON (ResponseSubscribeFailure code message mbPaths extra) =
+    Aeson.object $ baseKeyValues <> addonKeyValues
+    where
+      baseKeyValues :: [ Aeson.Pair ]
+      baseKeyValues =
+        [ "type"  .= ("subscribe" :: Text)
+        , "code" .= (code :: Int)
+        , "message" .= (message :: Text)
+        , "extra" .= extra
+        ]
+
+      addonKeyValues :: [ Aeson.Pair ]
+      addonKeyValues =
+        case mbPaths of
+          Just paths -> [ "paths" .= paths ]
+          Nothing  -> []
+
+data ResponseUnsubscribeSuccess
+  = ResponseUnsubscribeSuccess
+  { unsubscribeSuccessPaths :: [Text]
+  }
+
+instance Aeson.ToJSON ResponseUnsubscribeSuccess where
+  toJSON (ResponseUnsubscribeSuccess paths) =
+    Aeson.object
+    [ "type"  .= ("unsubscribe" :: Text)
+    , "paths" .= paths
+    , "code" .= (200 :: Int)
+    , "message" .= ("You've been successfully unsubscribed from the paths" :: Text)
+    , "extra" .= Aeson.object []
+    ]
+
+data ResponseUnsubscribeFailure
+  = ResponseUnsubscribeFailure
+  { unsubscribeFailureStatusCode :: Int
+  , unsubscribeFailureMessage :: Text
+  , unsubscribeFailurePaths :: Maybe [Text]
+  , unsubscribeFailureExtraData :: Maybe Value
+  }
+
+instance Aeson.ToJSON ResponseUnsubscribeFailure where
+  toJSON (ResponseUnsubscribeFailure code message mbPaths extraData) =
+    Aeson.object $ baseKeyValues <> addonKeyValues
+    where
+      baseKeyValues :: [ Aeson.Pair ]
+      baseKeyValues =
+        [ "type"  .= ("unsubscribe" :: Text)
+        , "code" .= (code :: Int)
+        , "message" .= (message :: Text)
+        , "extra" .= extraData
+        ]
+
+      addonKeyValues :: [ Aeson.Pair ]
+      addonKeyValues =
+        case mbPaths of
+          Just paths -> [ "paths" .= paths ]
+          Nothing  -> []
+
+
+-- * Close Conn Reason
+
+data CloseType
+  = TypeSizeOutOfBounds
+  | TypeBinaryPayload
+  | TypeJsonDecodeError
+  | TypePayloadNotObject
+  | TypeMissingOrUnexpectedType
+  deriving (Show, Eq)
+
+-- https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/close#parameters
+
+-- Status codes in the range 3000-3999 are reserved for use by
+-- libraries, frameworks, and applications. The interpretation of these codes
+-- is undefined by this protocol.
+
+closeCode :: CloseType -> Word16
+closeCode TypeSizeOutOfBounds         = 3001
+closeCode TypeBinaryPayload           = 3002
+closeCode TypeJsonDecodeError         = 3003
+closeCode TypePayloadNotObject        = 3004
+closeCode TypeMissingOrUnexpectedType = 3005
+
+
+-- A string providing a custom WebSocket connection close reason (a concise human-readable prose explanation for the closure).
+-- The value must be no longer than 123 bytes (encoded in UTF-8).
+
+closeMessage :: CloseType -> Text
+closeMessage TypeSizeOutOfBounds
+  = "Received a payload size that is out of bounds"
+closeMessage TypeBinaryPayload
+  = "Received a payload using Binary instead of Text"
+closeMessage TypeJsonDecodeError
+  = "Received a payload that resulted in a JSON decode error"
+closeMessage TypePayloadNotObject
+  = "Received a JSON payload which is not an object"
+closeMessage TypeMissingOrUnexpectedType
+  = "Received a payload with a missing or unexpected value for 'type'"
+
+-- * Parsing
+
+maxPayloadBytes :: Int
+maxPayloadBytes = 1_000_000
+
+checkBounds
+  :: Lazy.ByteString
+  -> Either RequestMalformedError Lazy.ByteString
+checkBounds lazyBS = isOutOfBoundsAcc lazyBS 0
+  where
+    isOutOfBoundsAcc Lazy.ByteString.Empty _ = Right lazyBS
+    isOutOfBoundsAcc (Lazy.ByteString.Chunk chunk rest) accSize =
+      let accSize' = accSize + ByteString.length chunk in
+        if accSize' > maxPayloadBytes
+        then Left PayloadSizeOutOfBounds
+        else isOutOfBoundsAcc rest accSize'
+
+parseDataMessage
+  :: WebSockets.DataMessage -> RequestPayload
+parseDataMessage (WebSockets.Binary _ ) = RequestPayloadMalformed UnexpectedBinaryPayload
+parseDataMessage (WebSockets.Text utf8EncodedLazyByteString _ ) =
+  case parsedPayload of
+    (Left malformed) -> RequestPayloadMalformed malformed
+    (Right (Left subscribe)) -> RequestPayloadSubscribe subscribe
+    (Right (Right unsubscribe)) -> RequestPayloadUnsubscribe unsubscribe
+  where
+    parsedPayload
+      :: Either RequestMalformedError (Either RequestSubscribe RequestUnsubscribe)
+    parsedPayload = do
+      let
+        parseEither :: Aeson.Parser a -> Either String a
+        parseEither parser = Aeson.parseEither (const parser) ()
+
+        mapError = flip Bifunctor.first
+      
+      boundedBytestring <- checkBounds utf8EncodedLazyByteString
+      clientPayloadAeson <- Aeson.eitherDecode @Value boundedBytestring
+        `mapError` (JsonDecodeError . Text.pack)
+
+      case clientPayloadAeson of
+        (Aeson.Object clientPayloadObject) -> do
+          payloadType <- parseEither @RequestType (clientPayloadObject .: "type")
+            `mapError` (MissingOrUnexpectedType . Text.pack)
+
+          case payloadType of
+            RequestSubscribeType -> do
+              pathsParsed <- parseEither @[Text] (clientPayloadObject .: "paths")
+                `mapError` (SubscribePathsMissingOrMalformed . Text.pack)
+
+              mbToken <- parseEither @(Maybe Text) (clientPayloadObject .:? "token")
+                `mapError` (SubscribeTokenNotAString . Text.pack)
+
+              pure $ Left $ RequestSubscribe pathsParsed mbToken
+
+            RequestUnsubscribeType -> do
+              parsedPaths <- parseEither @[Text] (clientPayloadObject .: "paths")
+                `mapError` (UnsubscribePathsMissingOrMalformed . Text.pack)
+
+              pure $ Right $ RequestUnsubscribe parsedPaths
+
+        _ -> Left PayloadNotAnObject
+
+data RequestType
+  = RequestSubscribeType
+  | RequestUnsubscribeType
+
+instance Aeson.FromJSON RequestType where
+  parseJSON (Aeson.String "subscribe") = pure RequestSubscribeType
+  parseJSON (Aeson.String "unsubscribe") = pure RequestUnsubscribeType
+  parseJSON _ = fail "Expecting 'type' to be either 'subscribe' or 'unsubscribe'"
+  
+

--- a/server/src/Icepeak/Server/WebsocketServer/SingleSubscription.hs
+++ b/server/src/Icepeak/Server/WebsocketServer/SingleSubscription.hs
@@ -1,0 +1,90 @@
+module Icepeak.Server.WebsocketServer.SingleSubscription (handleClient) where
+
+import Control.Concurrent (modifyMVar_, newEmptyMVar)
+import Control.Concurrent.Async (withAsync)
+import Control.Concurrent.MVar (MVar, takeMVar)
+import Control.Exception (SomeAsyncException, SomeException, catch, finally, fromException, throwIO)
+import Control.Monad (forever)
+import Data.Aeson (Value)
+import Data.UUID (UUID)
+import System.Random (randomIO)
+
+import qualified Data.Aeson as Aeson
+import qualified Network.WebSockets as WS
+
+import Icepeak.Server.Store (Path)
+import Icepeak.Server.Core (Core, coreClients, withCoreMetrics, getCurrentValue)
+import qualified Icepeak.Server.Metrics as Metrics
+import qualified Icepeak.Server.Subscription as Subscription
+
+-- * Client handling
+
+newUUID :: IO UUID
+newUUID = randomIO
+
+handleClient :: WS.Connection -> Path -> Core -> IO ()
+handleClient conn path core = do
+  uuid <- newUUID
+  pathCurentValueMVar <- newEmptyMVar
+  let
+    state = coreClients core
+    onConnect = do
+      modifyMVar_ state
+        (pure . Subscription.subscribe path uuid 
+         (\writeToSub -> writeToSub pathCurentValueMVar))
+      withCoreMetrics core Metrics.incrementSubscribers
+    onDisconnect = do
+      modifyMVar_ state (pure . Subscription.unsubscribe path uuid)
+      withCoreMetrics core Metrics.decrementSubscribers
+    sendInitialValue = do
+      currentValue <- getCurrentValue core path
+      WS.sendTextData conn (Aeson.encode currentValue)
+    -- For each connection, we want to spawn a client thread with an associated
+    -- queue, in order to manage subscribers. `withAsync` acts as `forkIO` in this
+    -- context, with the assurance the child thread is killed when the parent is.
+    manageConnection = withAsync (updateThread conn pathCurentValueMVar)
+                                 (const $ keepTalking conn)
+
+    -- Simply ignore connection errors, otherwise, Warp handles the exception
+    -- and sends a 500 response in the middle of a WebSocket connection, and
+    -- that violates the WebSocket protocol.
+    -- Note that subscribers are still properly removed by the finally below.
+    handleConnectionError :: WS.ConnectionException -> IO ()
+    handleConnectionError _ = pure ()
+  -- Put the client in the subscription tree and keep the connection open.
+  -- Remove it when the connection is closed.
+  finally (onConnect >> sendInitialValue >> manageConnection) onDisconnect
+    `catch` handleConnectionError
+
+-- This function handles sending the updates to subscribers.
+updateThread :: WS.Connection -> MVar Value -> IO ()
+updateThread conn state =
+  let
+    send :: Value -> IO ()
+    send value =
+      WS.sendTextData conn (Aeson.encode value)
+      `catch`
+      sendFailed
+
+    sendFailed :: SomeException -> IO ()
+    sendFailed exc
+      -- Rethrow async exceptions, they are meant for inter-thread communication
+      -- (e.g. ThreadKilled) and we don't expect them at this point.
+      | Just asyncExc <- fromException exc = throwIO (asyncExc :: SomeAsyncException)
+      -- We want to catch all other errors in order to prevent them from
+      -- bubbling up and disrupting the broadcasts to other clients.
+      | otherwise = pure ()
+  in forever $ do
+      value <- takeMVar state
+      send value
+
+-- We don't send any messages here; sending is done by the update
+-- loop; it finds the client in the set of subscriptions. But we do
+-- need to keep the thread running, otherwise the connection will be
+-- closed. So we go into an infinite loop here.
+keepTalking :: WS.Connection -> IO ()
+keepTalking conn = forever $ do
+    -- Note: WS.receiveDataMessage will handle control messages automatically and e.g.
+    -- do the closing handshake of the websocket protocol correctly
+    WS.receiveDataMessage conn
+

--- a/server/src/Icepeak/Server/WebsocketServer/SingleSubscription.hs
+++ b/server/src/Icepeak/Server/WebsocketServer/SingleSubscription.hs
@@ -28,7 +28,8 @@ handleClient conn path core = do
     onConnect = do
       modifyMVar_ state
         (pure . Subscription.subscribe path uuid
-         (\writeToSub -> writeToSub pathCurentValueMVar))
+         (Utils.writeToSub core pathCurentValueMVar)
+        )
       withCoreMetrics core Metrics.incrementSubscribers
     onDisconnect = do
       modifyMVar_ state (pure . Subscription.unsubscribe path uuid)

--- a/server/src/Icepeak/Server/WebsocketServer/Utils.hs
+++ b/server/src/Icepeak/Server/WebsocketServer/Utils.hs
@@ -1,0 +1,8 @@
+module Icepeak.Server.WebsocketServer.Utils where
+
+import Data.UUID (UUID)
+
+import qualified System.Random as Random
+
+newUUID :: IO UUID
+newUUID = Random.randomIO

--- a/server/src/Icepeak/Server/WebsocketServer/Utils.hs
+++ b/server/src/Icepeak/Server/WebsocketServer/Utils.hs
@@ -1,8 +1,33 @@
 module Icepeak.Server.WebsocketServer.Utils where
 
+import Control.Concurrent.MVar (MVar)
 import Data.UUID (UUID)
+import Data.Aeson (Value)
 
+import qualified Control.Concurrent.MVar as MVar
 import qualified System.Random as Random
+import qualified Control.Monad as Monad
+import qualified Data.Maybe as Maybe
+
+import Icepeak.Server.Core (Core)
+
+import qualified Icepeak.Server.Core as Core
+import qualified Icepeak.Server.Metrics as Metrics
 
 newUUID :: IO UUID
 newUUID = Random.randomIO
+
+-- this function is imported by both 'MultiSubscription.hs' and 'SingleSubscription.hs'
+-- it is subscription logic that they both have in common
+writeToSub :: Core -> MVar Value -> Value -> IO ()
+writeToSub core queue val = do
+  -- We are the only producer, so either the subscriber already
+  -- read the value or we can discard it to replace it with the
+  -- new one. We don't need atomicity for this operation.
+  -- `tryTakeMVar` basically empties the MVar, from this perspective.
+  mbQueue <- MVar.tryTakeMVar queue
+  -- If the MVar has not yet been read by the subscriber thread, it means
+  -- that the update has been skipped.
+  Monad.when (Maybe.isJust mbQueue) $
+    Monad.forM_ (Core.coreMetrics core) Metrics.incrementWsSkippedUpdates
+  MVar.putMVar queue val

--- a/server/tests/Icepeak/Server/MultiSubscriptionSpec.hs
+++ b/server/tests/Icepeak/Server/MultiSubscriptionSpec.hs
@@ -1,0 +1,329 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE NumericUnderscores #-}
+
+module Icepeak.Server.MultiSubscriptionSpec (spec) where
+
+import qualified Icepeak.Server.Server as Icepeak
+import qualified Icepeak.Server.Logger as Icepeak
+import qualified Icepeak.Server.Config as Icepeak
+import qualified Icepeak.Server.WebsocketServer as Icepeak
+import qualified Icepeak.Server.Core as Icepeak
+import qualified Icepeak.Server.Store as Icepeak
+import qualified Icepeak.Server.HttpServer as IcepeakHttp
+import qualified Icepeak.Server.WebsocketServer.Payload as Icepeak
+
+import Test.Hspec
+import Test.Hspec.Expectations.Json
+
+import qualified Network.WebSockets.Client as WS
+import qualified Network.WebSockets.Connection as WS
+import qualified Network.WebSockets as WS
+
+import Data.Aeson ((.=))
+import qualified Data.Aeson as Aeson
+
+import qualified Control.Concurrent as MVar
+import qualified Control.Concurrent.Async as Async
+import qualified Control.Concurrent as Concurrent
+
+import qualified Control.Exception as Exception
+
+import Data.Word (Word16)
+import Data.Text (Text)
+
+import qualified Data.ByteString.Lazy as BS.Lazy
+
+
+icepeakPort :: Int
+icepeakPort = 9898
+
+data Icepeak = Icepeak
+  { icepeakCore :: Icepeak.Core
+  , icepeakShutdown :: IO ()
+  }
+
+defaultConfig
+  :: Icepeak.Config
+defaultConfig
+  = Icepeak.Config
+  { Icepeak.configDataFile = Nothing
+  , Icepeak.configPort = icepeakPort
+  , Icepeak.configEnableJwtAuth = False
+  , Icepeak.configJwtSecret = Nothing
+  , Icepeak.configMetricsEndpoint = Nothing
+  , Icepeak.configQueueCapacity = 256
+  , Icepeak.configSyncIntervalMicroSeconds = Nothing
+  , Icepeak.configEnableJournaling = False
+  , Icepeak.configDisableSentryLogging = True
+  , Icepeak.configSentryDSN = Nothing
+  , Icepeak.configStorageBackend = Icepeak.File
+  , Icepeak.configSyncLogging = False
+  , Icepeak.configWebSocketPingInterval = 1
+  , Icepeak.configWebSocketPongTimeout = 1
+  }
+
+withIcepeak :: IO Icepeak
+withIcepeak = do
+  let config = defaultConfig
+  logger <- Icepeak.newLogger config
+  (Right core) <- Icepeak.newCore config logger Nothing
+  let wsServer = Icepeak.acceptConnection core
+  application <- IcepeakHttp.new core
+
+  -- Thread that accepts websocket connections
+  webserverThread <- Async.async $ Icepeak.runServer logger wsServer application icepeakPort
+
+  -- Thread that processes the Icepeak.Command queue
+  commandLoopThread <- Async.async $ Icepeak.runCommandLoop core
+
+  -- Thread that posts updates to websocket clients
+  webSocketThread <- Async.async $ Icepeak.processUpdates core
+
+  pure $ Icepeak
+    { icepeakCore = core
+    , icepeakShutdown = mapM_ Async.cancel [webserverThread, commandLoopThread, webSocketThread ]
+    }
+
+createDataSet :: Icepeak -> IO ()
+createDataSet icepeak = do
+  mapM_ (makeModification (icepeakCore icepeak))
+    [ Icepeak.Put ["A", "A"] "A"
+    , Icepeak.Put ["A", "B"] "B"
+    , Icepeak.Put ["B"] "B"
+    ]
+
+makeModification :: Icepeak.Core -> Icepeak.Modification -> IO ()
+makeModification core modification = do
+  waitMVar <- MVar.newEmptyMVar
+  Icepeak.enqueueCommand (Icepeak.Modify modification (Just waitMVar)) core
+  MVar.takeMVar waitMVar
+
+data CloseExpectation
+  = Unexpected String
+  | CloseCode Word16
+  deriving (Show, Eq)
+
+openReusableIcepeakConn :: (WS.Connection -> IO a) -> IO a
+openReusableIcepeakConn = WS.runClient "localhost" icepeakPort "/?method=reusable"
+
+sendJson :: WS.Connection -> Aeson.Value -> IO ()
+sendJson conn value = WS.sendDataMessage conn (WS.Text (Aeson.encode value) Nothing)
+
+expectDataMessage :: WS.Connection -> IO WS.DataMessage
+expectDataMessage conn = do
+  Right msg <- Async.race
+    (do Concurrent.threadDelay 100_000 -- 0.1 s
+        expectationFailure "Client expected a message, but did not receive anything for the duration of the 0.1s timeout")
+    (WS.receiveDataMessage conn)
+  pure msg
+
+expectNoMessage :: WS.Connection -> IO ()
+expectNoMessage conn = do
+  Left () <- Async.race
+    (Concurrent.threadDelay 10_000) -- 0.01s
+    (WS.receiveDataMessage conn >>=
+      (\p -> expectationFailure
+        $ "Client received an unexpected payload: " <> show p))
+  pure ()
+
+withResponseJson :: WS.Connection -> (Aeson.Value -> Expectation) -> Expectation
+withResponseJson conn jsonCheck = do
+  (WS.Text payload _) <- expectDataMessage conn
+  (Just json) <- pure $ Aeson.decode payload
+  jsonCheck json
+
+invalidPayloadsSpec :: SpecWith a
+invalidPayloadsSpec = describe "Opening and sending invalid payloads" $ do
+  it "should close connection upon invalid payload" $ const $ do
+    let openThenSend dataMessage = openReusableIcepeakConn $ \conn ->
+          do WS.sendDataMessage conn dataMessage
+             Exception.catch
+               (do unexpectedDataMessage <- WS.receiveDataMessage conn
+                   pure (Unexpected $ "Received data message when socket close was expected: " <> show unexpectedDataMessage))
+               
+               (\case (WS.CloseRequest code _) -> pure $ CloseCode code
+                      otherException -> pure $ Unexpected ("Unexpected exception: " <> show otherException))
+
+    notJSON <- openThenSend (WS.Text "Hello" Nothing)
+    notJSON `shouldBe` CloseCode (Icepeak.closeCode Icepeak.TypeJsonDecodeError)
+
+    binaryMessage <- openThenSend (WS.Binary "Hello")
+    binaryMessage `shouldBe` CloseCode (Icepeak.closeCode Icepeak.TypeBinaryPayload)
+
+    notAnObject <- openThenSend (WS.Text (Aeson.encode $ Aeson.Number 3) Nothing)
+    notAnObject `shouldBe` CloseCode (Icepeak.closeCode Icepeak.TypePayloadNotObject)
+
+    unexpectedType <- openThenSend (WS.Text (Aeson.encode $ Aeson.object [ "type" .= ("subskribe" :: String) ]) Nothing)
+    unexpectedType `shouldBe` CloseCode (Icepeak.closeCode Icepeak.TypeMissingOrUnexpectedType)
+
+    noType <- openThenSend (WS.Text (Aeson.encode $ Aeson.object [ ]) Nothing)
+    noType `shouldBe` CloseCode (Icepeak.closeCode Icepeak.TypeMissingOrUnexpectedType)
+
+    outOfBounds <- openThenSend (WS.Text (BS.Lazy.replicate (fromInteger (toInteger $ Icepeak.maxPayloadBytes + 1)) 0) Nothing)
+    outOfBounds `shouldBe` CloseCode (Icepeak.closeCode Icepeak.TypeSizeOutOfBounds)
+
+    insideOfBounds <- openThenSend (WS.Text (BS.Lazy.replicate (fromInteger (toInteger Icepeak.maxPayloadBytes)) 0) Nothing)
+    insideOfBounds `shouldNotBe` CloseCode (Icepeak.closeCode Icepeak.TypeSizeOutOfBounds)
+
+singleConnectionCommunicationSpec :: SpecWith Icepeak
+singleConnectionCommunicationSpec = aroundAllWith
+  (\specUsingArgs icepeak -> openReusableIcepeakConn (curry specUsingArgs icepeak))
+  $ describe "Communication over a single connection" $ do
+  succesfulSubscribe
+  succesfulReceiveUpdates
+  succesfulUnsubscribe
+  succesfulUnsubscribeNoUpdates
+  
+succesfulSubscribe :: SpecWith (Icepeak, WS.Connection)
+succesfulSubscribe = it "should subscribe and receive success response with values"
+  $ \(_, clientConn) -> do
+  
+  sendJson clientConn $ Aeson.object
+    [ "type" .= ("subscribe" :: Text)
+    , "paths" .= ([ "A/B", "A/A" ] :: [Text]) ]
+  withResponseJson clientConn
+    (\responseJson -> do
+        responseJson `shouldMatchJson` Aeson.object
+          [ "type" .= ("subscribe" :: Text)
+          , "code" .= (200 :: Int)
+          , "paths" .= 
+            [ Aeson.object
+              [ "path"  .= ("A/B" :: Text)
+              , "value" .= ("B":: Text)
+              ]
+            , Aeson.object
+              [ "path"  .= ("A/A" :: Text)
+              , "value" .= ("A":: Text)
+              ]
+            ]])
+
+  sendJson clientConn $ Aeson.object
+    [ "type" .= ("subscribe" :: Text)
+    , "paths" .= ([ "NULL" ] :: [Text]) ]
+  withResponseJson clientConn
+    (\responseJson -> do
+        responseJson `shouldMatchJson` Aeson.object
+          [ "type" .= ("subscribe" :: Text)
+          , "code" .= (200 :: Int)
+          , "paths" .= 
+            [ Aeson.object
+              [ "path"  .= ("NULL" :: Text)
+              , "value" .= Aeson.Null
+              ]
+            ]])
+
+succesfulReceiveUpdates :: SpecWith (Icepeak, WS.Connection)
+succesfulReceiveUpdates = it "should receive updates" $
+  \(icepeak, clientConn) -> do
+    makeModification (icepeakCore icepeak) (Icepeak.Put ["A", "A"] "C")
+    withResponseJson clientConn
+      (\responseJson -> do
+          responseJson `shouldMatchJson` Aeson.object
+            [ "type" .= ("update" :: Text)
+            , "value" .= ("C" :: Text)
+            ])
+
+    makeModification (icepeakCore icepeak) (Icepeak.Put ["A"] "C")
+    withResponseJson clientConn
+      (\responseJson -> do
+          responseJson `shouldMatchJson` Aeson.object
+            [ "type" .= ("update" :: Text)
+            , "value" .= Aeson.Null
+            ])
+    withResponseJson clientConn
+      (\responseJson -> do
+          responseJson `shouldMatchJson` Aeson.object
+            [ "type" .= ("update" :: Text)
+            , "value" .= Aeson.Null
+            ])
+
+    makeModification (icepeakCore icepeak) (Icepeak.Put ["A", "A"] "C")
+    withResponseJson clientConn
+      (\responseJson -> do
+          responseJson `shouldMatchJson` Aeson.object
+            [ "type" .= ("update" :: Text)
+            , "value" .= ("C" :: Text)
+            , "path" .= ("A/A" :: Text)
+            ])
+
+    makeModification (icepeakCore icepeak) (Icepeak.Delete ["A", "A"])
+    withResponseJson clientConn
+      (\responseJson -> do
+          responseJson `shouldMatchJson` Aeson.object
+            [ "type" .= ("update" :: Text)
+            , "value" .= Aeson.Null
+            , "path" .= ("A/A" :: Text)
+            ])
+
+    makeModification (icepeakCore icepeak) (Icepeak.Put ["A", "A"] "D")
+    withResponseJson clientConn
+      (\responseJson -> do
+          responseJson `shouldMatchJson` Aeson.object
+            [ "type" .= ("update" :: Text)
+            , "value" .= ("D" :: Text)
+            , "path" .= ("A/A" :: Text)
+            ])
+
+succesfulUnsubscribe :: SpecWith (Icepeak, WS.Connection)
+succesfulUnsubscribe = it "should unsubscribe and receive success response" $
+  \(_icepeak, clientConn) -> do
+    
+    sendJson clientConn $ Aeson.object
+      [ "type" .= ("unsubscribe" :: Text)
+      , "paths" .= ([ "A/B", "A/A" ] :: [Text]) ]
+    withResponseJson clientConn
+      (\responseJson -> do
+          responseJson `shouldMatchJson` Aeson.object
+            [ "type" .= ("unsubscribe" :: Text)
+            , "code" .= (200 :: Int)
+            , "paths" .= ([ "A/B", "A/A" ] :: [Text])
+            ])
+
+    sendJson clientConn $ Aeson.object
+      [ "type" .= ("unsubscribe" :: Text)
+      , "paths" .= ([ "NULL/NULL", "NULL/NULL" ] :: [Text]) ]
+    withResponseJson clientConn
+      (\responseJson -> do
+          responseJson `shouldMatchJson` Aeson.object
+            [ "type" .= ("unsubscribe" :: Text)
+            , "code" .= (200 :: Int)
+            , "paths" .= ([ "NULL/NULL", "NULL/NULL" ] :: [Text])
+            ])
+
+succesfulUnsubscribeNoUpdates :: SpecWith (Icepeak, WS.Connection)
+succesfulUnsubscribeNoUpdates = it "should no longer receive updates for unsusbscribed paths" $
+  \(icepeak, clientConn) -> do
+    makeModification (icepeakCore icepeak) (Icepeak.Put ["A", "B"] "C")
+    expectNoMessage clientConn >>= shouldBe ()
+
+    makeModification (icepeakCore icepeak) (Icepeak.Put ["A", "A"] "C")
+    expectNoMessage clientConn >>= shouldBe ()
+
+    sendJson clientConn $ Aeson.object
+      [ "type" .= ("subscribe" :: Text)
+      , "paths" .= ([ "A/B" ] :: [Text]) ]
+    withResponseJson clientConn
+      (\responseJson -> do
+          responseJson `shouldMatchJson` Aeson.object
+            [ "type" .= ("subscribe" :: Text)
+            , "code" .= (200 :: Int)
+            , "paths" .= [ Aeson.object [ "path" .= ("A/B" :: Text), "value" .= ("C" :: Text)] ] 
+            ])
+
+    expectNoMessage clientConn >>= shouldBe ()
+
+    
+            
+spec :: Spec
+spec =
+  aroundAll
+  (\testSpec -> do
+      icepeak <- withIcepeak
+      createDataSet icepeak
+      testSpec icepeak
+      icepeakShutdown icepeak)
+  $ describe "MultiSubscription connection protocol"
+  $ do invalidPayloadsSpec
+       singleConnectionCommunicationSpec

--- a/server/tests/Icepeak/Server/MultiSubscriptionSpec.hs
+++ b/server/tests/Icepeak/Server/MultiSubscriptionSpec.hs
@@ -182,13 +182,13 @@ singleConnectionCommunicationSpec :: SpecWith Icepeak
 singleConnectionCommunicationSpec = aroundAllWith
   (\specUsingArgs icepeak -> openReusableIcepeakConn (curry specUsingArgs icepeak))
   $ describe "Communication over a single connection" $ do
-  succesfulSubscribe
-  succesfulReceiveUpdates
-  succesfulUnsubscribe
-  succesfulUnsubscribeNoUpdates
+  successfulSubscribe
+  successfulReceiveUpdates
+  successfulUnsubscribe
+  successfulUnsubscribeNoUpdates
   
-succesfulSubscribe :: SpecWith (Icepeak, WS.Connection)
-succesfulSubscribe = it "should subscribe and receive success response with values"
+successfulSubscribe :: SpecWith (Icepeak, WS.Connection)
+successfulSubscribe = it "should subscribe and receive success response with values"
   $ \(_, clientConn) -> do
   
   sendJson clientConn $ Aeson.object
@@ -225,8 +225,8 @@ succesfulSubscribe = it "should subscribe and receive success response with valu
               ]
             ]])
 
-succesfulReceiveUpdates :: SpecWith (Icepeak, WS.Connection)
-succesfulReceiveUpdates = it "should receive updates" $
+successfulReceiveUpdates :: SpecWith (Icepeak, WS.Connection)
+successfulReceiveUpdates = it "should receive updates" $
   \(icepeak, clientConn) -> do
     makeModification (icepeakCore icepeak) (Icepeak.Put ["A", "A"] "C")
     withResponseJson clientConn
@@ -277,8 +277,8 @@ succesfulReceiveUpdates = it "should receive updates" $
             , "path" .= ("A/A" :: Text)
             ])
 
-succesfulUnsubscribe :: SpecWith (Icepeak, WS.Connection)
-succesfulUnsubscribe = it "should unsubscribe and receive success response" $
+successfulUnsubscribe :: SpecWith (Icepeak, WS.Connection)
+successfulUnsubscribe = it "should unsubscribe and receive success response" $
   \(_icepeak, clientConn) -> do
     
     sendJson clientConn $ Aeson.object
@@ -303,8 +303,8 @@ succesfulUnsubscribe = it "should unsubscribe and receive success response" $
             , "paths" .= ([ "NULL/NULL", "NULL/NULL" ] :: [Text])
             ])
 
-succesfulUnsubscribeNoUpdates :: SpecWith (Icepeak, WS.Connection)
-succesfulUnsubscribeNoUpdates = it "should no longer receive updates for unsusbscribed paths" $
+successfulUnsubscribeNoUpdates :: SpecWith (Icepeak, WS.Connection)
+successfulUnsubscribeNoUpdates = it "should no longer receive updates for unsusbscribed paths" $
   \(icepeak, clientConn) -> do
     makeModification (icepeakCore icepeak) (Icepeak.Put ["A", "B"] "C")
     expectNoMessage clientConn >>= shouldBe ()

--- a/server/tests/Icepeak/Server/MultiSubscriptionSpec.hs
+++ b/server/tests/Icepeak/Server/MultiSubscriptionSpec.hs
@@ -47,7 +47,7 @@ data Icepeak = Icepeak
 
 defaultConfig
   :: Icepeak.Config
-defaultConfig 
+defaultConfig
   = Icepeak.Config
   { Icepeak.configDataFile = Nothing
   , Icepeak.configPort = icepeakPort
@@ -77,7 +77,7 @@ withIcepeak = do
         Left err -> do expectationFailure ("Failed to create Core: " <> err)
                        undefined
         Right core -> pure core)
-  
+
   let wsServer = Icepeak.acceptConnection core
   application <- IcepeakHttp.new core
 
@@ -153,7 +153,7 @@ invalidPayloadsSpec = describe "Opening and sending invalid payloads" $ do
              Exception.catch
                (do unexpectedDataMessage <- WS.receiveDataMessage conn
                    pure (Unexpected $ "Received data message when socket close was expected: " <> show unexpectedDataMessage))
-               
+
                (\case (WS.CloseRequest code _) -> pure $ CloseCode code
                       otherException -> pure $ Unexpected ("Unexpected exception: " <> show otherException))
 
@@ -186,11 +186,11 @@ singleConnectionCommunicationSpec = aroundAllWith
   successfulReceiveUpdates
   successfulUnsubscribe
   successfulUnsubscribeNoUpdates
-  
+
 successfulSubscribe :: SpecWith (Icepeak, WS.Connection)
 successfulSubscribe = it "should subscribe and receive success response with values"
   $ \(_, clientConn) -> do
-  
+
   sendJson clientConn $ Aeson.object
     [ "type" .= ("subscribe" :: Text)
     , "paths" .= ([ "A/B", "A/A" ] :: [Text]) ]
@@ -199,7 +199,7 @@ successfulSubscribe = it "should subscribe and receive success response with val
         responseJson `shouldMatchJson` Aeson.object
           [ "type" .= ("subscribe" :: Text)
           , "code" .= (200 :: Int)
-          , "paths" .= 
+          , "paths" .=
             [ Aeson.object
               [ "path"  .= ("A/B" :: Text)
               , "value" .= ("B":: Text)
@@ -218,7 +218,7 @@ successfulSubscribe = it "should subscribe and receive success response with val
         responseJson `shouldMatchJson` Aeson.object
           [ "type" .= ("subscribe" :: Text)
           , "code" .= (200 :: Int)
-          , "paths" .= 
+          , "paths" .=
             [ Aeson.object
               [ "path"  .= ("NULL" :: Text)
               , "value" .= Aeson.Null
@@ -280,7 +280,7 @@ successfulReceiveUpdates = it "should receive updates" $
 successfulUnsubscribe :: SpecWith (Icepeak, WS.Connection)
 successfulUnsubscribe = it "should unsubscribe and receive success response" $
   \(_icepeak, clientConn) -> do
-    
+
     sendJson clientConn $ Aeson.object
       [ "type" .= ("unsubscribe" :: Text)
       , "paths" .= ([ "A/B", "A/A" ] :: [Text]) ]
@@ -320,13 +320,13 @@ successfulUnsubscribeNoUpdates = it "should no longer receive updates for unsusb
           responseJson `shouldMatchJson` Aeson.object
             [ "type" .= ("subscribe" :: Text)
             , "code" .= (200 :: Int)
-            , "paths" .= [ Aeson.object [ "path" .= ("A/B" :: Text), "value" .= ("C" :: Text)] ] 
+            , "paths" .= [ Aeson.object [ "path" .= ("A/B" :: Text), "value" .= ("C" :: Text)] ]
             ])
 
     expectNoMessage clientConn >>= shouldBe ()
 
-    
-            
+
+
 spec :: Spec
 spec =
   aroundAll

--- a/server/tests/Spec.hs
+++ b/server/tests/Spec.hs
@@ -9,6 +9,7 @@ import qualified Icepeak.Server.RequestSpec
 import qualified Icepeak.Server.SocketSpec
 import qualified Icepeak.Server.StoreSpec
 import qualified Icepeak.Server.SubscriptionTreeSpec
+import qualified Icepeak.Server.MultiSubscriptionSpec
 
 main :: IO ()
 main = hspec $ do
@@ -21,3 +22,4 @@ main = hspec $ do
   Icepeak.Server.SocketSpec.spec
   Icepeak.Server.StoreSpec.spec
   Icepeak.Server.SubscriptionTreeSpec.spec
+  Icepeak.Server.MultiSubscriptionSpec.spec


### PR DESCRIPTION
### Current State of Draft

Added 2 additional modules to separate new behaviour from old:

```
Icepeak.Server.WebsocketServer.HandleClientSingleSubscription
Icepeak.Server.WebsocketServer.HandleClientMultiSubscription
 ```
Current draft implements the ability for the client thread to :
- Client thread to case split on payloads, and sub and un-sub from the subscription tree accordingly.
- Client thread to receive and read from multiple paths in the subscription tree, and send to socket.
- Client thread to disconnect, and clean up the subscription tree after itself.

Left to do:
- [x] Payload parsing.
- [x] Authenticate the token and path.
- [x] Handle the un-authorised case.
- [x] Handle the unrecognised payload case.
- [x] Dispatch old vs new behaviour based on request.
- [x] Other protocol specific details.