### PR TITLE
Upgrade Semaphore CI image to 22.04

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -5,7 +5,7 @@ name: "Icepeak CI Pipeline"
 agent:
   machine:
     type: "f1-standard-2"
-    os_image: "ubuntu2004"
+    os_image: "ubuntu2204"
 
 blocks:
   - name: "Build and test"


### PR DESCRIPTION
## Description

Part of [#12385](https://github.com/https://github.com/channable/devops/issues/12385)
Upgrades Semaphore CI image from 20.04 to 22.04