### PR TITLE
Add /healthcheck endpoint to the metrics server

### DIFF
--- a/server/icepeak.cabal
+++ b/server/icepeak.cabal
@@ -183,6 +183,7 @@ test-suite spec
     Icepeak.Server.SocketSpec
     Icepeak.Server.StoreSpec
     Icepeak.Server.SubscriptionTreeSpec
+    Icepeak.Server.MetricsServerSpec
     Icepeak.Server.MultiSubscriptionSpec
     OrphanInstances
     Paths_icepeak

--- a/server/src/Icepeak/Server/MetricsServer.hs
+++ b/server/src/Icepeak/Server/MetricsServer.hs
@@ -29,8 +29,9 @@ metricsApp request respond
 
 runMetricsServer :: Logger -> MetricsConfig -> IO ()
 runMetricsServer logger metricsConfig = do
-  postLog logger LogInfo $ "Metrics provided on "
+  postLog logger LogInfo $ "Metrics and healthcheck provided on "
     <> (Text.pack $ show $ metricsConfigHost metricsConfig)
     <> ":"
     <> (Text.pack $ show $ metricsConfigPort metricsConfig)
+    <> " (/metrics, /healthcheck)"
   Warp.runSettings (metricsServerConfig metricsConfig) metricsApp

--- a/server/src/Icepeak/Server/MetricsServer.hs
+++ b/server/src/Icepeak/Server/MetricsServer.hs
@@ -3,6 +3,8 @@ module Icepeak.Server.MetricsServer where
 
 import           Data.Function                     ((&))
 import qualified Data.Text                         as Text
+import qualified Network.HTTP.Types                as Http
+import qualified Network.Wai                       as Wai
 import qualified Network.Wai.Handler.Warp          as Warp
 import qualified Network.Wai.Middleware.Prometheus as PrometheusWai
 
@@ -14,10 +16,21 @@ metricsServerConfig config = Warp.defaultSettings
   & Warp.setHost (metricsConfigHost config)
   & Warp.setPort (metricsConfigPort config)
 
+-- | WAI application that serves:
+--   GET /healthcheck  -> 200 OK
+--   everything else   -> Prometheus metrics
+metricsApp :: Wai.Application
+metricsApp request respond
+  | Wai.requestMethod request == Http.methodGet
+  , Wai.pathInfo request == ["healthcheck"]
+  = respond $ Wai.responseLBS Http.status200 [] ""
+  | otherwise
+  = PrometheusWai.metricsApp request respond
+
 runMetricsServer :: Logger -> MetricsConfig -> IO ()
 runMetricsServer logger metricsConfig = do
   postLog logger LogInfo $ "Metrics provided on "
     <> (Text.pack $ show $ metricsConfigHost metricsConfig)
     <> ":"
     <> (Text.pack $ show $ metricsConfigPort metricsConfig)
-  Warp.runSettings (metricsServerConfig metricsConfig) PrometheusWai.metricsApp
+  Warp.runSettings (metricsServerConfig metricsConfig) metricsApp

--- a/server/tests/Icepeak/Server/MetricsServerSpec.hs
+++ b/server/tests/Icepeak/Server/MetricsServerSpec.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Icepeak.Server.MetricsServerSpec (spec) where
+
+import Test.Hspec
+import Test.Hspec.Wai
+
+import Icepeak.Server.MetricsServer (metricsApp)
+
+spec :: Spec
+spec = describe "metricsApp" $ with (pure metricsApp) $ do
+  describe "GET /healthcheck" $ do
+    it "returns 200 OK" $
+      get "/healthcheck" `shouldRespondWith` 200
+
+    it "returns an empty body" $
+      get "/healthcheck" `shouldRespondWith` "" { matchStatus = 200 }
+
+  describe "GET /metrics" $ do
+    it "returns 200 OK" $
+      get "/metrics" `shouldRespondWith` 200

--- a/server/tests/Spec.hs
+++ b/server/tests/Spec.hs
@@ -9,6 +9,7 @@ import qualified Icepeak.Server.RequestSpec
 import qualified Icepeak.Server.SocketSpec
 import qualified Icepeak.Server.StoreSpec
 import qualified Icepeak.Server.SubscriptionTreeSpec
+import qualified Icepeak.Server.MetricsServerSpec
 import qualified Icepeak.Server.MultiSubscriptionSpec
 
 main :: IO ()
@@ -17,6 +18,7 @@ main = hspec $ do
   Icepeak.Server.ApiSpec.spec
   Icepeak.Server.CoreSpec.spec
   Icepeak.Server.JwtSpec.spec
+  Icepeak.Server.MetricsServerSpec.spec
   Icepeak.Server.PersistenceSpec.spec
   Icepeak.Server.RequestSpec.spec
   Icepeak.Server.SocketSpec.spec


### PR DESCRIPTION
The metrics server was being misused as a Consul health check, since
icepeak had no dedicated liveness endpoint. This adds GET /healthcheck
on the same host/port as the metrics server (configured via --metrics),
returning 200 OK with an empty body.

The routing is handled inside a new metricsApp WAI application that
intercepts GET /healthcheck and falls through to the Prometheus metrics
app for all other requests. No new dependencies are required.